### PR TITLE
DSEGOG-9 user can remove columns with close icon and middle mouse click

### DIFF
--- a/src/table/__snapshots__/columnCheckboxes.component.test.tsx.snap
+++ b/src/table/__snapshots__/columnCheckboxes.component.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`Column Checkboxes renders correctly when checked 1`] = `
         class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root Mui-checked css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
       >
         <input
+          aria-label="id checkbox"
           checked=""
           class="PrivateSwitchBase-input css-1m9pwf3"
           data-indeterminate="false"
@@ -48,6 +49,7 @@ exports[`Column Checkboxes renders correctly when checked 1`] = `
         class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root Mui-checked css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
       >
         <input
+          aria-label="name checkbox"
           checked=""
           class="PrivateSwitchBase-input css-1m9pwf3"
           data-indeterminate="false"
@@ -90,6 +92,7 @@ exports[`Column Checkboxes renders correctly when unchecked 1`] = `
         class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
       >
         <input
+          aria-label="id checkbox"
           class="PrivateSwitchBase-input css-1m9pwf3"
           data-indeterminate="false"
           id="id"
@@ -122,6 +125,7 @@ exports[`Column Checkboxes renders correctly when unchecked 1`] = `
         class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
       >
         <input
+          aria-label="name checkbox"
           class="PrivateSwitchBase-input css-1m9pwf3"
           data-indeterminate="false"
           id="name"

--- a/src/table/__snapshots__/table.component.test.tsx.snap
+++ b/src/table/__snapshots__/table.component.test.tsx.snap
@@ -20,227 +20,209 @@ exports[`Table renders correctly 1`] = `
                 role="row"
               >
                 <th
-                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-1ygcj2i-MuiTableCell-root"
-                  colspan="1"
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
                   role="columnheader"
                   scope="col"
                 >
                   <div
-                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
-                    scope="col"
+                    style="overflow: hidden; flex: 1;"
                   >
                     <div
-                      style="overflow: hidden; flex: 1;"
+                      aria-label="id header"
+                      class="MuiBox-root css-k008qs"
                     >
                       <div
-                        aria-label="id header"
-                        class="MuiBox-root css-k008qs"
+                        class="MuiBox-root css-12z0wuy"
+                      />
+                      <div
+                        class="MuiBox-root css-0"
                       >
-                        <div
-                          class="MuiBox-root css-12z0wuy"
-                        />
-                        <div
-                          class="MuiBox-root css-0"
+                        <span
+                          class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                          data-testid="sort id"
+                          role="button"
+                          tabindex="0"
                         >
-                          <span
-                            class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
-                            data-testid="sort id"
-                            role="button"
-                            tabindex="0"
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
                           >
-                            <p
-                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
-                            >
-                              ID
-                            </p>
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
-                              data-testid="ArrowDownwardIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                              />
-                            </svg>
-                          </span>
-                        </div>
-                        <div
-                          aria-label="close id"
-                        >
+                            ID
+                          </p>
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
-                            data-testid="CloseIcon"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                            data-testid="ArrowDownwardIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
                           >
                             <path
-                              d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                              d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
                             />
                           </svg>
-                        </div>
+                        </span>
+                      </div>
+                      <div
+                        aria-label="close id"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                          data-testid="CloseIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                          />
+                        </svg>
                       </div>
                     </div>
-                    <div>
-                      <div
-                        style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
-                      >
-                        <hr
-                          class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
-                        />
-                      </div>
+                  </div>
+                  <div>
+                    <div
+                      style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
+                    >
+                      <hr
+                        class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
+                      />
                     </div>
                   </div>
                 </th>
                 <th
-                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-1ygcj2i-MuiTableCell-root"
-                  colspan="1"
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
                   role="columnheader"
                   scope="col"
                 >
                   <div
-                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
-                    scope="col"
+                    style="overflow: hidden; flex: 1;"
                   >
                     <div
-                      style="overflow: hidden; flex: 1;"
+                      aria-label="shotNum header"
+                      class="MuiBox-root css-k008qs"
                     >
                       <div
-                        aria-label="shotNum header"
-                        class="MuiBox-root css-k008qs"
+                        class="MuiBox-root css-12z0wuy"
+                      />
+                      <div
+                        class="MuiBox-root css-0"
                       >
-                        <div
-                          class="MuiBox-root css-12z0wuy"
-                        />
-                        <div
-                          class="MuiBox-root css-0"
+                        <span
+                          class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                          data-testid="sort shotNum"
+                          role="button"
+                          tabindex="0"
                         >
-                          <span
-                            class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
-                            data-testid="sort shotNum"
-                            role="button"
-                            tabindex="0"
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
                           >
-                            <p
-                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
-                            >
-                              Shot Number
-                            </p>
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
-                              data-testid="ArrowDownwardIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                              />
-                            </svg>
-                          </span>
-                        </div>
-                        <div
-                          aria-label="close shotNum"
-                        >
+                            Shot Number
+                          </p>
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
-                            data-testid="CloseIcon"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                            data-testid="ArrowDownwardIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
                           >
                             <path
-                              d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                              d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
                             />
                           </svg>
-                        </div>
+                        </span>
+                      </div>
+                      <div
+                        aria-label="close shotNum"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                          data-testid="CloseIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                          />
+                        </svg>
                       </div>
                     </div>
-                    <div>
-                      <div
-                        style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
-                      >
-                        <hr
-                          class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
-                        />
-                      </div>
+                  </div>
+                  <div>
+                    <div
+                      style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
+                    >
+                      <hr
+                        class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
+                      />
                     </div>
                   </div>
                 </th>
                 <th
-                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-1ygcj2i-MuiTableCell-root"
-                  colspan="1"
+                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
                   role="columnheader"
                   scope="col"
                 >
                   <div
-                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
-                    scope="col"
+                    style="overflow: hidden; flex: 1;"
                   >
                     <div
-                      style="overflow: hidden; flex: 1;"
+                      aria-label="timestamp header"
+                      class="MuiBox-root css-k008qs"
                     >
                       <div
-                        aria-label="timestamp header"
-                        class="MuiBox-root css-k008qs"
+                        class="MuiBox-root css-12z0wuy"
+                      />
+                      <div
+                        class="MuiBox-root css-0"
                       >
-                        <div
-                          class="MuiBox-root css-12z0wuy"
-                        />
-                        <div
-                          class="MuiBox-root css-0"
+                        <span
+                          class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                          data-testid="sort timestamp"
+                          role="button"
+                          tabindex="0"
                         >
-                          <span
-                            class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
-                            data-testid="sort timestamp"
-                            role="button"
-                            tabindex="0"
+                          <p
+                            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
                           >
-                            <p
-                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
-                            >
-                              Timestamp
-                            </p>
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
-                              data-testid="ArrowDownwardIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                              />
-                            </svg>
-                          </span>
-                        </div>
-                        <div
-                          aria-label="close timestamp"
-                        >
+                            Timestamp
+                          </p>
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
-                            data-testid="CloseIcon"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                            data-testid="ArrowDownwardIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
                           >
                             <path
-                              d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                              d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
                             />
                           </svg>
-                        </div>
+                        </span>
+                      </div>
+                      <div
+                        aria-label="close timestamp"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                          data-testid="CloseIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                          />
+                        </svg>
                       </div>
                     </div>
-                    <div>
-                      <div
-                        style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
-                      >
-                        <hr
-                          class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
-                        />
-                      </div>
+                  </div>
+                  <div>
+                    <div
+                      style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
+                    >
+                      <hr
+                        class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
+                      />
                     </div>
                   </div>
                 </th>

--- a/src/table/__snapshots__/table.component.test.tsx.snap
+++ b/src/table/__snapshots__/table.component.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`Table renders correctly 1`] = `
                       style="overflow: hidden; flex: 1;"
                     >
                       <div
+                        aria-label="id header"
                         class="MuiBox-root css-k008qs"
                       >
                         <div
@@ -64,6 +65,21 @@ exports[`Table renders correctly 1`] = `
                             </svg>
                           </span>
                         </div>
+                        <div
+                          aria-label="close id"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                            data-testid="CloseIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            />
+                          </svg>
+                        </div>
                       </div>
                     </div>
                     <div>
@@ -91,6 +107,7 @@ exports[`Table renders correctly 1`] = `
                       style="overflow: hidden; flex: 1;"
                     >
                       <div
+                        aria-label="shotNum header"
                         class="MuiBox-root css-k008qs"
                       >
                         <div
@@ -122,6 +139,21 @@ exports[`Table renders correctly 1`] = `
                             </svg>
                           </span>
                         </div>
+                        <div
+                          aria-label="close shotNum"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                            data-testid="CloseIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            />
+                          </svg>
+                        </div>
                       </div>
                     </div>
                     <div>
@@ -149,6 +181,7 @@ exports[`Table renders correctly 1`] = `
                       style="overflow: hidden; flex: 1;"
                     >
                       <div
+                        aria-label="timestamp header"
                         class="MuiBox-root css-k008qs"
                       >
                         <div
@@ -179,6 +212,21 @@ exports[`Table renders correctly 1`] = `
                               />
                             </svg>
                           </span>
+                        </div>
+                        <div
+                          aria-label="close timestamp"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                            data-testid="CloseIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            />
+                          </svg>
                         </div>
                       </div>
                     </div>

--- a/src/table/__snapshots__/table.component.test.tsx.snap
+++ b/src/table/__snapshots__/table.component.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`Table renders correctly 1`] = `
                         >
                           <span
                             class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                            data-testid="sort id"
                             role="button"
                             tabindex="0"
                           >
@@ -118,6 +119,7 @@ exports[`Table renders correctly 1`] = `
                         >
                           <span
                             class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                            data-testid="sort shotNum"
                             role="button"
                             tabindex="0"
                           >
@@ -192,6 +194,7 @@ exports[`Table renders correctly 1`] = `
                         >
                           <span
                             class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                            data-testid="sort timestamp"
                             role="button"
                             tabindex="0"
                           >

--- a/src/table/columnCheckboxes.component.test.tsx
+++ b/src/table/columnCheckboxes.component.test.tsx
@@ -49,13 +49,13 @@ describe('Column Checkboxes', () => {
 
   it('calls onChecked when checkbox is clicked', () => {
     createView();
-    screen.getAllByRole('checkbox')[0].click();
+    screen.getByLabelText('id checkbox').click();
     expect(onChecked).toHaveBeenCalledWith('id', true);
 
     cleanup();
     props.displayedColumns = availableColumns;
     createView();
-    screen.getAllByRole('checkbox')[1].click();
+    screen.getByLabelText('name checkbox').click();
     expect(onChecked).toHaveBeenCalledWith('name', false);
   });
 

--- a/src/table/columnCheckboxes.component.tsx
+++ b/src/table/columnCheckboxes.component.tsx
@@ -30,6 +30,9 @@ const ColumnCheckboxes = (props: ColumnCheckboxesProps): React.ReactElement => {
           id={accessor}
           value={accessor}
           checked={shouldBeChecked(accessor)}
+          inputProps={{
+            'aria-label': `${accessor} checkbox`,
+          }}
         />
       </div>
     ) : null;

--- a/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
+++ b/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
@@ -2,134 +2,148 @@
 
 exports[`Data Header renders correctly with sort but no filter 1`] = `
 <DocumentFragment>
-  <div
-    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
-  >
-    <div
-      style="overflow: hidden; flex: 1;"
-    >
-      <div
-        aria-label="test header"
-        class="MuiBox-root css-k008qs"
-      >
-        <div
-          class="MuiBox-root css-12z0wuy"
+  <table>
+    <thead>
+      <tr>
+        <th
+          class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
+          role="columnheader"
         >
-          <div>
-            Test
+          <div
+            style="overflow: hidden; flex: 1;"
+          >
+            <div
+              aria-label="test header"
+              class="MuiBox-root css-k008qs"
+            >
+              <div
+                class="MuiBox-root css-12z0wuy"
+              >
+                <div>
+                  Test
+                </div>
+              </div>
+              <div
+                class="MuiBox-root css-0"
+              >
+                <span
+                  class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                  data-testid="sort test"
+                  role="button"
+                  tabindex="0"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
+                  >
+                    Test
+                  </p>
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                    data-testid="ArrowDownwardIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                aria-label="close test"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                  data-testid="CloseIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
           </div>
-        </div>
-        <div
-          class="MuiBox-root css-0"
-        >
-          <span
-            class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
-            data-testid="sort test"
-            role="button"
-            tabindex="0"
-          >
-            <p
-              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
+          <div>
+            <div
+              style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
             >
-              Test
-            </p>
-            <svg
-              aria-hidden="true"
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
-              data-testid="ArrowDownwardIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+              <hr
+                class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
               />
-            </svg>
-          </span>
-        </div>
-        <div
-          aria-label="close test"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
-            data-testid="CloseIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-            />
-          </svg>
-        </div>
-      </div>
-    </div>
-    <div>
-      <div
-        style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
-      >
-        <hr
-          class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
-        />
-      </div>
-    </div>
-  </div>
+            </div>
+          </div>
+        </th>
+      </tr>
+    </thead>
+  </table>
 </DocumentFragment>
 `;
 
 exports[`Data Header renders correctly without sort or filter 1`] = `
 <DocumentFragment>
-  <div
-    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
-  >
-    <div
-      style="overflow: hidden; flex: 1;"
-    >
-      <div
-        aria-label="test header"
-        class="MuiBox-root css-k008qs"
-      >
-        <div
-          class="MuiBox-root css-12z0wuy"
+  <table>
+    <thead>
+      <tr>
+        <th
+          class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
+          role="columnheader"
         >
-          <div>
-            Test
+          <div
+            style="overflow: hidden; flex: 1;"
+          >
+            <div
+              aria-label="test header"
+              class="MuiBox-root css-k008qs"
+            >
+              <div
+                class="MuiBox-root css-12z0wuy"
+              >
+                <div>
+                  Test
+                </div>
+              </div>
+              <div
+                class="MuiBox-root css-0"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
+                >
+                  Test
+                </p>
+              </div>
+              <div
+                aria-label="close test"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                  data-testid="CloseIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                  />
+                </svg>
+              </div>
+            </div>
           </div>
-        </div>
-        <div
-          class="MuiBox-root css-0"
-        >
-          <p
-            class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
-          >
-            Test
-          </p>
-        </div>
-        <div
-          aria-label="close test"
-        >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
-            data-testid="CloseIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-            />
-          </svg>
-        </div>
-      </div>
-    </div>
-    <div>
-      <div
-        style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
-      >
-        <hr
-          class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
-        />
-      </div>
-    </div>
-  </div>
+          <div>
+            <div
+              style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
+            >
+              <hr
+                class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
+              />
+            </div>
+          </div>
+        </th>
+      </tr>
+    </thead>
+  </table>
 </DocumentFragment>
 `;

--- a/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
+++ b/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`Data Header renders correctly with sort but no filter 1`] = `
         >
           <span
             class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+            data-testid="sort test"
             role="button"
             tabindex="0"
           >

--- a/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
+++ b/src/table/headerRenderers/__snapshots__/dataHeader.component.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`Data Header renders correctly with sort but no filter 1`] = `
       style="overflow: hidden; flex: 1;"
     >
       <div
+        aria-label="test header"
         class="MuiBox-root css-k008qs"
       >
         <div
@@ -44,6 +45,21 @@ exports[`Data Header renders correctly with sort but no filter 1`] = `
             </svg>
           </span>
         </div>
+        <div
+          aria-label="close test"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+            data-testid="CloseIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+            />
+          </svg>
+        </div>
       </div>
     </div>
     <div>
@@ -68,6 +84,7 @@ exports[`Data Header renders correctly without sort or filter 1`] = `
       style="overflow: hidden; flex: 1;"
     >
       <div
+        aria-label="test header"
         class="MuiBox-root css-k008qs"
       >
         <div
@@ -85,6 +102,21 @@ exports[`Data Header renders correctly without sort or filter 1`] = `
           >
             Test
           </p>
+        </div>
+        <div
+          aria-label="close test"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+            data-testid="CloseIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+            />
+          </svg>
         </div>
       </div>
     </div>

--- a/src/table/headerRenderers/dataHeader.component.test.tsx
+++ b/src/table/headerRenderers/dataHeader.component.test.tsx
@@ -13,7 +13,15 @@ describe('Data Header', () => {
   const onClose = jest.fn();
 
   const createView = (): RenderResult => {
-    return render(<DataHeader {...props} />);
+    return render(
+      <table>
+        <thead>
+          <tr>
+            <DataHeader {...props} />
+          </tr>
+        </thead>
+      </table>
+    );
   };
 
   beforeEach(() => {

--- a/src/table/headerRenderers/dataHeader.component.test.tsx
+++ b/src/table/headerRenderers/dataHeader.component.test.tsx
@@ -68,7 +68,7 @@ describe('Data Header', () => {
   describe('calls the onSort method when label is clicked', () => {
     it('sets asc order', () => {
       createView();
-      screen.getAllByText('Test')[1].click();
+      screen.getByTestId('sort test').click();
       expect(onSort).toHaveBeenCalledWith('test', 'asc');
     });
 
@@ -78,7 +78,7 @@ describe('Data Header', () => {
       };
 
       createView();
-      screen.getAllByText('Test')[1].click();
+      screen.getByTestId('sort test').click();
       expect(onSort).toHaveBeenCalledWith('test', 'desc');
     });
 
@@ -88,7 +88,7 @@ describe('Data Header', () => {
       };
 
       createView();
-      screen.getAllByText('Test')[1].click();
+      screen.getByTestId('sort test').click();
       expect(onSort).toHaveBeenCalledWith('test', null);
     });
   });

--- a/src/table/headerRenderers/dataHeader.component.test.tsx
+++ b/src/table/headerRenderers/dataHeader.component.test.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import DataHeader, { DataHeaderProps } from './dataHeader.component';
-import { render, RenderResult, screen } from '@testing-library/react';
+import {
+  render,
+  RenderResult,
+  screen,
+  fireEvent,
+} from '@testing-library/react';
 
 describe('Data Header', () => {
   let props: DataHeaderProps;
   const onSort = jest.fn();
+  const onClose = jest.fn();
 
   const createView = (): RenderResult => {
     return render(<DataHeader {...props} />);
@@ -12,10 +18,10 @@ describe('Data Header', () => {
 
   beforeEach(() => {
     props = {
-      key: 'test',
       dataKey: 'test',
       sort: {},
       onSort: onSort,
+      onClose: onClose,
       label: 'Test',
       icon: function Icon() {
         return <div>Test</div>;
@@ -36,6 +42,23 @@ describe('Data Header', () => {
   it('renders correctly with sort but no filter', () => {
     const view = createView();
     expect(view.asFragment()).toMatchSnapshot();
+  });
+
+  it('calls onClose when close icon is clicked', () => {
+    createView();
+    const icon = screen.getByLabelText('close test');
+
+    // eslint-disable-next-line testing-library/no-node-access
+    fireEvent.click(icon.firstChild);
+
+    expect(onClose).toHaveBeenCalledWith('test');
+  });
+
+  it('removes column from display when header is middle clicked', () => {
+    createView();
+    const header = screen.getByLabelText('test header');
+    fireEvent.mouseDown(header, { button: 1 });
+    expect(onClose).toHaveBeenCalledWith('test');
   });
 
   it.todo('renders correctly with filter but no sort');

--- a/src/table/headerRenderers/dataHeader.component.tsx
+++ b/src/table/headerRenderers/dataHeader.component.tsx
@@ -86,7 +86,8 @@ const DataHeader = (props: DataHeaderProps): React.ReactElement => {
   return (
     <TableCell
       size="small"
-      component="div"
+      component="th"
+      role="columnheader"
       sx={sx}
       variant="head"
       sortDirection={currSortDirection}
@@ -114,8 +115,6 @@ const DataHeader = (props: DataHeaderProps): React.ReactElement => {
             <StyledClose onClick={() => onClose(dataKey)} />
           </div>
         </Box>
-
-        {/* {filterComponent?.(labelString, dataKey)} */}
       </div>
       {/* Draggable? */}
       <div>

--- a/src/table/headerRenderers/dataHeader.component.tsx
+++ b/src/table/headerRenderers/dataHeader.component.tsx
@@ -6,6 +6,7 @@ import {
   TableCell,
   SxProps,
 } from '@mui/material';
+import Close from '@mui/icons-material/Close';
 import React from 'react';
 import { Order } from '../../app.types';
 
@@ -18,6 +19,7 @@ export interface DataHeaderProps {
   defaultSort?: Order;
   label?: React.ReactNode;
   icon?: React.ComponentType<unknown>;
+  onClose: (column: string) => void;
 }
 
 const DataHeader = (props: DataHeaderProps): React.ReactElement => {
@@ -30,6 +32,7 @@ const DataHeader = (props: DataHeaderProps): React.ReactElement => {
     onSort,
     defaultSort,
     label,
+    onClose,
   } = props;
 
   const currSortDirection = sort[dataKey];
@@ -88,6 +91,7 @@ const DataHeader = (props: DataHeaderProps): React.ReactElement => {
           <Box marginRight={1}>{Icon && <Icon />}</Box>
           <Box>{inner}</Box>
         </Box>
+        <Close onClick={() => onClose(dataKey)} />
         {/* {filterComponent?.(labelString, dataKey)} */}
       </div>
       {/* Draggable? */}

--- a/src/table/headerRenderers/dataHeader.component.tsx
+++ b/src/table/headerRenderers/dataHeader.component.tsx
@@ -97,6 +97,7 @@ const DataHeader = (props: DataHeaderProps): React.ReactElement => {
         }}
       >
         <Box
+          aria-label={`${dataKey} header`}
           display="flex"
           onMouseDown={(event) => {
             // Middle mouse button can also fire onClose
@@ -108,7 +109,9 @@ const DataHeader = (props: DataHeaderProps): React.ReactElement => {
         >
           <Box marginRight={1}>{Icon && <Icon />}</Box>
           <Box>{inner}</Box>
-          <StyledClose onClick={() => onClose(dataKey)} />
+          <div aria-label={`close ${dataKey}`}>
+            <StyledClose onClick={() => onClose(dataKey)} />
+          </div>
         </Box>
 
         {/* {filterComponent?.(labelString, dataKey)} */}

--- a/src/table/headerRenderers/dataHeader.component.tsx
+++ b/src/table/headerRenderers/dataHeader.component.tsx
@@ -5,10 +5,19 @@ import {
   Divider,
   TableCell,
   SxProps,
+  styled,
 } from '@mui/material';
 import Close from '@mui/icons-material/Close';
 import React from 'react';
 import { Order } from '../../app.types';
+
+const StyledClose = styled(Close)(() => ({
+  cursor: 'pointer',
+  color: 'black',
+  '&:hover': {
+    color: 'red',
+  },
+}));
 
 export interface DataHeaderProps {
   disableSort?: boolean;
@@ -87,11 +96,21 @@ const DataHeader = (props: DataHeaderProps): React.ReactElement => {
           flex: 1,
         }}
       >
-        <Box display="flex">
+        <Box
+          display="flex"
+          onMouseDown={(event) => {
+            // Middle mouse button can also fire onClose
+            if (event.button === 1) {
+              event.preventDefault();
+              onClose(dataKey);
+            }
+          }}
+        >
           <Box marginRight={1}>{Icon && <Icon />}</Box>
           <Box>{inner}</Box>
+          <StyledClose onClick={() => onClose(dataKey)} />
         </Box>
-        <Close onClick={() => onClose(dataKey)} />
+
         {/* {filterComponent?.(labelString, dataKey)} */}
       </div>
       {/* Draggable? */}

--- a/src/table/headerRenderers/dataHeader.component.tsx
+++ b/src/table/headerRenderers/dataHeader.component.tsx
@@ -68,6 +68,7 @@ const DataHeader = (props: DataHeaderProps): React.ReactElement => {
 
   const inner = !disableSort ? (
     <TableSortLabel
+      data-testid={`sort ${dataKey}`}
       active={dataKey in sort}
       direction={currSortDirection}
       onClick={() => onSort(dataKey, nextSortDirection)}

--- a/src/table/table.component.tsx
+++ b/src/table/table.component.tsx
@@ -24,6 +24,7 @@ export interface TableProps {
   onPageChange: (page: number) => void;
   sort: { [column: string]: Order };
   onSort: (column: string, order: Order | null) => void;
+  onClose: (column: string) => void;
 }
 
 const Table = React.memo((props: TableProps): React.ReactElement => {
@@ -37,6 +38,7 @@ const Table = React.memo((props: TableProps): React.ReactElement => {
     onPageChange,
     sort,
     onSort,
+    onClose,
   } = props;
 
   const [maxPage, setMaxPage] = React.useState(0);
@@ -91,6 +93,7 @@ const Table = React.memo((props: TableProps): React.ReactElement => {
                                 sort={sort}
                                 onSort={onSort}
                                 label={column.render('Header')}
+                                onClose={onClose}
                               />
                             </MuiTableCell>
                           );

--- a/src/table/table.component.tsx
+++ b/src/table/table.component.tsx
@@ -87,15 +87,15 @@ const Table = React.memo((props: TableProps): React.ReactElement => {
                           const { key, ...otherHeaderProps } =
                             column.getHeaderProps();
                           return (
-                            <MuiTableCell key={key} {...otherHeaderProps}>
-                              <DataHeader
-                                dataKey={column.render('id') as string}
-                                sort={sort}
-                                onSort={onSort}
-                                label={column.render('Header')}
-                                onClose={onClose}
-                              />
-                            </MuiTableCell>
+                            <DataHeader
+                              key={key}
+                              {...otherHeaderProps}
+                              dataKey={column.render('id') as string}
+                              sort={sort}
+                              onSort={onSort}
+                              label={column.render('Header')}
+                              onClose={onClose}
+                            />
                           );
                         })}
                       </MuiTableRow>

--- a/src/views/__snapshots__/recordTable.component.test.tsx.snap
+++ b/src/views/__snapshots__/recordTable.component.test.tsx.snap
@@ -45,6 +45,7 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
                           >
                             <span
                               class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                              data-testid="sort id"
                               role="button"
                               tabindex="0"
                             >
@@ -119,6 +120,7 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
                           >
                             <span
                               class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                              data-testid="sort shotNum"
                               role="button"
                               tabindex="0"
                             >
@@ -193,6 +195,7 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
                           >
                             <span
                               class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                              data-testid="sort timestamp"
                               role="button"
                               tabindex="0"
                             >
@@ -267,6 +270,7 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
                           >
                             <span
                               class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                              data-testid="sort test1"
                               role="button"
                               tabindex="0"
                             >
@@ -341,6 +345,7 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
                           >
                             <span
                               class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                              data-testid="sort test2"
                               role="button"
                               tabindex="0"
                             >
@@ -415,6 +420,7 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
                           >
                             <span
                               class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                              data-testid="sort test3"
                               role="button"
                               tabindex="0"
                             >
@@ -699,6 +705,7 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
           class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root Mui-checked css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
         >
           <input
+            aria-label="id checkbox"
             class="PrivateSwitchBase-input css-1m9pwf3"
             data-indeterminate="false"
             id="id"
@@ -731,6 +738,7 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
           class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root Mui-checked css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
         >
           <input
+            aria-label="shotNum checkbox"
             class="PrivateSwitchBase-input css-1m9pwf3"
             data-indeterminate="false"
             id="shotNum"
@@ -763,6 +771,7 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
           class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root Mui-checked css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
         >
           <input
+            aria-label="timestamp checkbox"
             class="PrivateSwitchBase-input css-1m9pwf3"
             data-indeterminate="false"
             id="timestamp"
@@ -795,6 +804,7 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
           class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root Mui-checked css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
         >
           <input
+            aria-label="test1 checkbox"
             class="PrivateSwitchBase-input css-1m9pwf3"
             data-indeterminate="false"
             id="test1"
@@ -827,6 +837,7 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
           class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root Mui-checked css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
         >
           <input
+            aria-label="test2 checkbox"
             class="PrivateSwitchBase-input css-1m9pwf3"
             data-indeterminate="false"
             id="test2"
@@ -859,6 +870,7 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
           class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root Mui-checked css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
         >
           <input
+            aria-label="test3 checkbox"
             class="PrivateSwitchBase-input css-1m9pwf3"
             data-indeterminate="false"
             id="test3"
@@ -1023,6 +1035,7 @@ exports[`Record Table renders correctly with no displayed columns 1`] = `
           class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
         >
           <input
+            aria-label="id checkbox"
             class="PrivateSwitchBase-input css-1m9pwf3"
             data-indeterminate="false"
             id="id"
@@ -1055,6 +1068,7 @@ exports[`Record Table renders correctly with no displayed columns 1`] = `
           class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
         >
           <input
+            aria-label="shotNum checkbox"
             class="PrivateSwitchBase-input css-1m9pwf3"
             data-indeterminate="false"
             id="shotNum"
@@ -1087,6 +1101,7 @@ exports[`Record Table renders correctly with no displayed columns 1`] = `
           class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
         >
           <input
+            aria-label="timestamp checkbox"
             class="PrivateSwitchBase-input css-1m9pwf3"
             data-indeterminate="false"
             id="timestamp"
@@ -1119,6 +1134,7 @@ exports[`Record Table renders correctly with no displayed columns 1`] = `
           class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
         >
           <input
+            aria-label="test1 checkbox"
             class="PrivateSwitchBase-input css-1m9pwf3"
             data-indeterminate="false"
             id="test1"
@@ -1151,6 +1167,7 @@ exports[`Record Table renders correctly with no displayed columns 1`] = `
           class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
         >
           <input
+            aria-label="test2 checkbox"
             class="PrivateSwitchBase-input css-1m9pwf3"
             data-indeterminate="false"
             id="test2"
@@ -1183,6 +1200,7 @@ exports[`Record Table renders correctly with no displayed columns 1`] = `
           class="MuiCheckbox-root MuiCheckbox-colorPrimary MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
         >
           <input
+            aria-label="test3 checkbox"
             class="PrivateSwitchBase-input css-1m9pwf3"
             data-indeterminate="false"
             id="test3"

--- a/src/views/__snapshots__/recordTable.component.test.tsx.snap
+++ b/src/views/__snapshots__/recordTable.component.test.tsx.snap
@@ -21,452 +21,416 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
                   role="row"
                 >
                   <th
-                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-1ygcj2i-MuiTableCell-root"
-                    colspan="1"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
                     role="columnheader"
                     scope="col"
                   >
                     <div
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
-                      scope="col"
+                      style="overflow: hidden; flex: 1;"
                     >
                       <div
-                        style="overflow: hidden; flex: 1;"
+                        aria-label="id header"
+                        class="MuiBox-root css-k008qs"
                       >
                         <div
-                          aria-label="id header"
-                          class="MuiBox-root css-k008qs"
+                          class="MuiBox-root css-12z0wuy"
+                        />
+                        <div
+                          class="MuiBox-root css-0"
                         >
-                          <div
-                            class="MuiBox-root css-12z0wuy"
-                          />
-                          <div
-                            class="MuiBox-root css-0"
+                          <span
+                            class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                            data-testid="sort id"
+                            role="button"
+                            tabindex="0"
                           >
-                            <span
-                              class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
-                              data-testid="sort id"
-                              role="button"
-                              tabindex="0"
+                            <p
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
                             >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
-                              >
-                                id
-                              </p>
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
-                                data-testid="ArrowDownwardIcon"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                          <div
-                            aria-label="close id"
-                          >
+                              id
+                            </p>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
-                              data-testid="CloseIcon"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                              data-testid="ArrowDownwardIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
                               <path
-                                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
                               />
                             </svg>
-                          </div>
+                          </span>
+                        </div>
+                        <div
+                          aria-label="close id"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                            data-testid="CloseIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            />
+                          </svg>
                         </div>
                       </div>
-                      <div>
-                        <div
-                          style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
-                        >
-                          <hr
-                            class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
-                          />
-                        </div>
+                    </div>
+                    <div>
+                      <div
+                        style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
+                      >
+                        <hr
+                          class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
+                        />
                       </div>
                     </div>
                   </th>
                   <th
-                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-1ygcj2i-MuiTableCell-root"
-                    colspan="1"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
                     role="columnheader"
                     scope="col"
                   >
                     <div
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
-                      scope="col"
+                      style="overflow: hidden; flex: 1;"
                     >
                       <div
-                        style="overflow: hidden; flex: 1;"
+                        aria-label="shotNum header"
+                        class="MuiBox-root css-k008qs"
                       >
                         <div
-                          aria-label="shotNum header"
-                          class="MuiBox-root css-k008qs"
+                          class="MuiBox-root css-12z0wuy"
+                        />
+                        <div
+                          class="MuiBox-root css-0"
                         >
-                          <div
-                            class="MuiBox-root css-12z0wuy"
-                          />
-                          <div
-                            class="MuiBox-root css-0"
+                          <span
+                            class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                            data-testid="sort shotNum"
+                            role="button"
+                            tabindex="0"
                           >
-                            <span
-                              class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
-                              data-testid="sort shotNum"
-                              role="button"
-                              tabindex="0"
+                            <p
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
                             >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
-                              >
-                                shotNum
-                              </p>
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
-                                data-testid="ArrowDownwardIcon"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                          <div
-                            aria-label="close shotNum"
-                          >
+                              shotNum
+                            </p>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
-                              data-testid="CloseIcon"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                              data-testid="ArrowDownwardIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
                               <path
-                                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
                               />
                             </svg>
-                          </div>
+                          </span>
+                        </div>
+                        <div
+                          aria-label="close shotNum"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                            data-testid="CloseIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            />
+                          </svg>
                         </div>
                       </div>
-                      <div>
-                        <div
-                          style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
-                        >
-                          <hr
-                            class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
-                          />
-                        </div>
+                    </div>
+                    <div>
+                      <div
+                        style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
+                      >
+                        <hr
+                          class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
+                        />
                       </div>
                     </div>
                   </th>
                   <th
-                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-1ygcj2i-MuiTableCell-root"
-                    colspan="1"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
                     role="columnheader"
                     scope="col"
                   >
                     <div
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
-                      scope="col"
+                      style="overflow: hidden; flex: 1;"
                     >
                       <div
-                        style="overflow: hidden; flex: 1;"
+                        aria-label="timestamp header"
+                        class="MuiBox-root css-k008qs"
                       >
                         <div
-                          aria-label="timestamp header"
-                          class="MuiBox-root css-k008qs"
+                          class="MuiBox-root css-12z0wuy"
+                        />
+                        <div
+                          class="MuiBox-root css-0"
                         >
-                          <div
-                            class="MuiBox-root css-12z0wuy"
-                          />
-                          <div
-                            class="MuiBox-root css-0"
+                          <span
+                            class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                            data-testid="sort timestamp"
+                            role="button"
+                            tabindex="0"
                           >
-                            <span
-                              class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
-                              data-testid="sort timestamp"
-                              role="button"
-                              tabindex="0"
+                            <p
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
                             >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
-                              >
-                                timestamp
-                              </p>
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
-                                data-testid="ArrowDownwardIcon"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                          <div
-                            aria-label="close timestamp"
-                          >
+                              timestamp
+                            </p>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
-                              data-testid="CloseIcon"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                              data-testid="ArrowDownwardIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
                               <path
-                                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
                               />
                             </svg>
-                          </div>
+                          </span>
+                        </div>
+                        <div
+                          aria-label="close timestamp"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                            data-testid="CloseIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            />
+                          </svg>
                         </div>
                       </div>
-                      <div>
-                        <div
-                          style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
-                        >
-                          <hr
-                            class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
-                          />
-                        </div>
+                    </div>
+                    <div>
+                      <div
+                        style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
+                      >
+                        <hr
+                          class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
+                        />
                       </div>
                     </div>
                   </th>
                   <th
-                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-1ygcj2i-MuiTableCell-root"
-                    colspan="1"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
                     role="columnheader"
                     scope="col"
                   >
                     <div
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
-                      scope="col"
+                      style="overflow: hidden; flex: 1;"
                     >
                       <div
-                        style="overflow: hidden; flex: 1;"
+                        aria-label="test1 header"
+                        class="MuiBox-root css-k008qs"
                       >
                         <div
-                          aria-label="test1 header"
-                          class="MuiBox-root css-k008qs"
+                          class="MuiBox-root css-12z0wuy"
+                        />
+                        <div
+                          class="MuiBox-root css-0"
                         >
-                          <div
-                            class="MuiBox-root css-12z0wuy"
-                          />
-                          <div
-                            class="MuiBox-root css-0"
+                          <span
+                            class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                            data-testid="sort test1"
+                            role="button"
+                            tabindex="0"
                           >
-                            <span
-                              class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
-                              data-testid="sort test1"
-                              role="button"
-                              tabindex="0"
+                            <p
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
                             >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
-                              >
-                                test1
-                              </p>
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
-                                data-testid="ArrowDownwardIcon"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                          <div
-                            aria-label="close test1"
-                          >
+                              test1
+                            </p>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
-                              data-testid="CloseIcon"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                              data-testid="ArrowDownwardIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
                               <path
-                                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
                               />
                             </svg>
-                          </div>
+                          </span>
+                        </div>
+                        <div
+                          aria-label="close test1"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                            data-testid="CloseIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            />
+                          </svg>
                         </div>
                       </div>
-                      <div>
-                        <div
-                          style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
-                        >
-                          <hr
-                            class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
-                          />
-                        </div>
+                    </div>
+                    <div>
+                      <div
+                        style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
+                      >
+                        <hr
+                          class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
+                        />
                       </div>
                     </div>
                   </th>
                   <th
-                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-1ygcj2i-MuiTableCell-root"
-                    colspan="1"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
                     role="columnheader"
                     scope="col"
                   >
                     <div
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
-                      scope="col"
+                      style="overflow: hidden; flex: 1;"
                     >
                       <div
-                        style="overflow: hidden; flex: 1;"
+                        aria-label="test2 header"
+                        class="MuiBox-root css-k008qs"
                       >
                         <div
-                          aria-label="test2 header"
-                          class="MuiBox-root css-k008qs"
+                          class="MuiBox-root css-12z0wuy"
+                        />
+                        <div
+                          class="MuiBox-root css-0"
                         >
-                          <div
-                            class="MuiBox-root css-12z0wuy"
-                          />
-                          <div
-                            class="MuiBox-root css-0"
+                          <span
+                            class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                            data-testid="sort test2"
+                            role="button"
+                            tabindex="0"
                           >
-                            <span
-                              class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
-                              data-testid="sort test2"
-                              role="button"
-                              tabindex="0"
+                            <p
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
                             >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
-                              >
-                                test2
-                              </p>
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
-                                data-testid="ArrowDownwardIcon"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                          <div
-                            aria-label="close test2"
-                          >
+                              test2
+                            </p>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
-                              data-testid="CloseIcon"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                              data-testid="ArrowDownwardIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
                               <path
-                                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
                               />
                             </svg>
-                          </div>
+                          </span>
+                        </div>
+                        <div
+                          aria-label="close test2"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                            data-testid="CloseIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            />
+                          </svg>
                         </div>
                       </div>
-                      <div>
-                        <div
-                          style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
-                        >
-                          <hr
-                            class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
-                          />
-                        </div>
+                    </div>
+                    <div>
+                      <div
+                        style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
+                      >
+                        <hr
+                          class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
+                        />
                       </div>
                     </div>
                   </th>
                   <th
-                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeMedium css-1ygcj2i-MuiTableCell-root"
-                    colspan="1"
+                    class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
                     role="columnheader"
                     scope="col"
                   >
                     <div
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-1howxi1-MuiTableCell-root"
-                      scope="col"
+                      style="overflow: hidden; flex: 1;"
                     >
                       <div
-                        style="overflow: hidden; flex: 1;"
+                        aria-label="test3 header"
+                        class="MuiBox-root css-k008qs"
                       >
                         <div
-                          aria-label="test3 header"
-                          class="MuiBox-root css-k008qs"
+                          class="MuiBox-root css-12z0wuy"
+                        />
+                        <div
+                          class="MuiBox-root css-0"
                         >
-                          <div
-                            class="MuiBox-root css-12z0wuy"
-                          />
-                          <div
-                            class="MuiBox-root css-0"
+                          <span
+                            class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
+                            data-testid="sort test3"
+                            role="button"
+                            tabindex="0"
                           >
-                            <span
-                              class="MuiButtonBase-root MuiTableSortLabel-root css-1qgma8u-MuiButtonBase-root-MuiTableSortLabel-root"
-                              data-testid="sort test3"
-                              role="button"
-                              tabindex="0"
+                            <p
+                              class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
                             >
-                              <p
-                                class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-xw0cpc-MuiTypography-root"
-                              >
-                                test3
-                              </p>
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
-                                data-testid="ArrowDownwardIcon"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                          <div
-                            aria-label="close test3"
-                          >
+                              test3
+                            </p>
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
-                              data-testid="CloseIcon"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiTableSortLabel-icon MuiTableSortLabel-iconDirectionAsc css-1vweko9-MuiSvgIcon-root-MuiTableSortLabel-icon"
+                              data-testid="ArrowDownwardIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
                             >
                               <path
-                                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
                               />
                             </svg>
-                          </div>
+                          </span>
+                        </div>
+                        <div
+                          aria-label="close test3"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                            data-testid="CloseIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            />
+                          </svg>
                         </div>
                       </div>
-                      <div>
-                        <div
-                          style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
-                        >
-                          <hr
-                            class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
-                          />
-                        </div>
+                    </div>
+                    <div>
+                      <div
+                        style="margin-left: 18px; padding-left: 4px; padding-right: 4px; cursor: col-resize;"
+                      >
+                        <hr
+                          class="MuiDivider-root MuiDivider-fullWidth MuiDivider-vertical MuiDivider-flexItem css-1i1qbzr-MuiDivider-root"
+                        />
                       </div>
                     </div>
                   </th>

--- a/src/views/__snapshots__/recordTable.component.test.tsx.snap
+++ b/src/views/__snapshots__/recordTable.component.test.tsx.snap
@@ -34,6 +34,7 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
                         style="overflow: hidden; flex: 1;"
                       >
                         <div
+                          aria-label="id header"
                           class="MuiBox-root css-k008qs"
                         >
                           <div
@@ -65,6 +66,21 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
                               </svg>
                             </span>
                           </div>
+                          <div
+                            aria-label="close id"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                              data-testid="CloseIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                              />
+                            </svg>
+                          </div>
                         </div>
                       </div>
                       <div>
@@ -92,6 +108,7 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
                         style="overflow: hidden; flex: 1;"
                       >
                         <div
+                          aria-label="shotNum header"
                           class="MuiBox-root css-k008qs"
                         >
                           <div
@@ -123,6 +140,21 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
                               </svg>
                             </span>
                           </div>
+                          <div
+                            aria-label="close shotNum"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                              data-testid="CloseIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                              />
+                            </svg>
+                          </div>
                         </div>
                       </div>
                       <div>
@@ -150,6 +182,7 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
                         style="overflow: hidden; flex: 1;"
                       >
                         <div
+                          aria-label="timestamp header"
                           class="MuiBox-root css-k008qs"
                         >
                           <div
@@ -181,6 +214,21 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
                               </svg>
                             </span>
                           </div>
+                          <div
+                            aria-label="close timestamp"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                              data-testid="CloseIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                              />
+                            </svg>
+                          </div>
                         </div>
                       </div>
                       <div>
@@ -208,6 +256,7 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
                         style="overflow: hidden; flex: 1;"
                       >
                         <div
+                          aria-label="test1 header"
                           class="MuiBox-root css-k008qs"
                         >
                           <div
@@ -239,6 +288,21 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
                               </svg>
                             </span>
                           </div>
+                          <div
+                            aria-label="close test1"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                              data-testid="CloseIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                              />
+                            </svg>
+                          </div>
                         </div>
                       </div>
                       <div>
@@ -266,6 +330,7 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
                         style="overflow: hidden; flex: 1;"
                       >
                         <div
+                          aria-label="test2 header"
                           class="MuiBox-root css-k008qs"
                         >
                           <div
@@ -297,6 +362,21 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
                               </svg>
                             </span>
                           </div>
+                          <div
+                            aria-label="close test2"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                              data-testid="CloseIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                              />
+                            </svg>
+                          </div>
                         </div>
                       </div>
                       <div>
@@ -324,6 +404,7 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
                         style="overflow: hidden; flex: 1;"
                       >
                         <div
+                          aria-label="test3 header"
                           class="MuiBox-root css-k008qs"
                         >
                           <div
@@ -354,6 +435,21 @@ exports[`Record Table renders correctly with columns displayed 1`] = `
                                 />
                               </svg>
                             </span>
+                          </div>
+                          <div
+                            aria-label="close test3"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pmilg0-MuiSvgIcon-root"
+                              data-testid="CloseIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                              />
+                            </svg>
                           </div>
                         </div>
                       </div>

--- a/src/views/recordTable.component.test.tsx
+++ b/src/views/recordTable.component.test.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { render, RenderResult, screen, act } from '@testing-library/react';
+import {
+  render,
+  RenderResult,
+  screen,
+  act,
+  fireEvent,
+} from '@testing-library/react';
 import RecordTable, { RecordTableProps } from './recordTable.component';
 import { testRecords, flushPromises } from '../setupTests';
 import { useRecordCount, useRecordsPaginated } from '../api/records';
@@ -138,6 +144,34 @@ describe('Record Table', () => {
       screen.getByLabelText('id').click();
       await flushPromises();
     });
+    idColumn = screen.getAllByRole('button').find((element) => {
+      return element.textContent === 'id';
+    });
+    expect(idColumn).toBeUndefined();
+  });
+
+  it('amends displayed columns when column close button is clicked', async () => {
+    createView();
+
+    await act(async () => {
+      screen.getByLabelText('id').click();
+      await flushPromises();
+    });
+
+    // Current rudimentary way to fetch the ID data header and not the ID checkbox
+    // The existence of this is used to "prove" that the ID column is on the screen
+    // Could do with some improving
+    let idColumn = screen.getAllByRole('button').find((element) => {
+      return element.textContent === 'id';
+    });
+
+    expect(idColumn).not.toBeUndefined();
+
+    const icon = screen.getByLabelText('close id');
+
+    // eslint-disable-next-line testing-library/no-node-access
+    fireEvent.click(icon.firstChild);
+
     idColumn = screen.getAllByRole('button').find((element) => {
       return element.textContent === 'id';
     });

--- a/src/views/recordTable.component.test.tsx
+++ b/src/views/recordTable.component.test.tsx
@@ -109,9 +109,9 @@ describe('Record Table', () => {
     createView();
 
     await act(async () => {
-      screen.getByLabelText('id').click();
+      screen.getByLabelText('id checkbox').click();
       await flushPromises();
-      screen.getAllByText('id')[0].click();
+      screen.getByTestId('sort id').click();
       await flushPromises();
     });
 

--- a/src/views/recordTable.component.tsx
+++ b/src/views/recordTable.component.tsx
@@ -129,6 +129,7 @@ const RecordTable = React.memo(
             return col.accessor !== accessor;
           })
         );
+        handleSort(accessor, null);
       }
     };
 

--- a/src/views/recordTable.component.tsx
+++ b/src/views/recordTable.component.tsx
@@ -132,6 +132,10 @@ const RecordTable = React.memo(
       }
     };
 
+    const handleClose = (column: string): void => {
+      onChecked(column, false);
+    };
+
     return (
       <div>
         <Table
@@ -145,6 +149,7 @@ const RecordTable = React.memo(
           onPageChange={onPageChange}
           sort={sort}
           onSort={handleSort}
+          onClose={handleClose}
         />
         <ColumnCheckboxes
           availableColumns={availableColumns}


### PR DESCRIPTION
## Description
The user is now able to more easily remove columns from display. A black cross icon is displayed in each column header which the user can click to remove the column. I also added in the ability for the user to click the entire column header with the middle mouse button as an alternative method for removing the column from display. This mimics the behaviour of popular web browsers, where a user can middle click a tab to close it. This may be a familiar action for some users and speed up their interaction with the site.

## Testing instructions
Try removing columns using both methods and test that the functionality works as expected. Try this across multiple pages to double check it's working. Also make sure that, when a column is closed, its checkbox is unticked at the bottom of the page.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes [DSEGOG-9](https://stfc.atlassian.net/jira/software/projects/DSEGOG/boards/22?selectedIssue=DSEGOG-9)