### PR TITLE
Updating VSCode editor sdk to support TS 4.8.2

### DIFF
--- a/.yarn/sdks/eslint/package.json
+++ b/.yarn/sdks/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint",
-  "version": "8.20.0-sdk",
+  "version": "8.23.0-sdk",
   "main": "./lib/api.js",
   "type": "commonjs"
 }

--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -61,28 +61,12 @@ const moduleWrapper = tsserver => {
           //
           // Ref: https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
           //
-          // 2021-10-08: VSCode changed the format in 1.61.
+          // Update Oct 8 2021: VSCode changed their format in 1.61.
           // Before | ^zip:/c:/foo/bar.zip/package.json
-          // After  | ^/zip//c:/foo/bar.zip/package.json
-          //
-          // 2022-04-06: VSCode changed the format in 1.66.
-          // Before | ^/zip//c:/foo/bar.zip/package.json
-          // After  | ^/zip/c:/foo/bar.zip/package.json
-          //
-          // 2022-05-06: VSCode changed the format in 1.68
-          // Before | ^/zip/c:/foo/bar.zip/package.json
           // After  | ^/zip//c:/foo/bar.zip/package.json
           //
           case `vscode <1.61`: {
             str = `^zip:${str}`;
-          } break;
-
-          case `vscode <1.66`: {
-            str = `^/zip/${str}`;
-          } break;
-
-          case `vscode <1.68`: {
-            str = `^/zip${str}`;
           } break;
 
           case `vscode`: {
@@ -135,7 +119,9 @@ const moduleWrapper = tsserver => {
 
       case `vscode`:
       default: {
-        return str.replace(/^\^?(zip:|\/zip(\/ts-nul-authority)?)\/+/, process.platform === `win32` ? `` : `/`)
+        return process.platform === `win32`
+          ? str.replace(/^\^?(zip:|\/zip)\/+/, ``)
+          : str.replace(/^\^?(zip:|\/zip)\/+/, `/`);
       } break;
     }
   }
@@ -174,21 +160,8 @@ const moduleWrapper = tsserver => {
         typeof parsedMessage.arguments.hostInfo === `string`
       ) {
         hostInfo = parsedMessage.arguments.hostInfo;
-        if (hostInfo === `vscode` && process.env.VSCODE_IPC_HOOK) {
-          const [, major, minor] = (process.env.VSCODE_IPC_HOOK.match(
-            // The RegExp from https://semver.org/ but without the caret at the start
-            /(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-          ) ?? []).map(Number)
-
-          if (major === 1) {
-            if (minor < 61) {
-              hostInfo += ` <1.61`;
-            } else if (minor < 66) {
-              hostInfo += ` <1.66`;
-            } else if (minor < 68) {
-              hostInfo += ` <1.68`;
-            }
-          }
+        if (hostInfo === `vscode` && process.env.VSCODE_IPC_HOOK && process.env.VSCODE_IPC_HOOK.match(/Code\/1\.([1-5][0-9]|60)\./)) {
+          hostInfo += ` <1.61`;
         }
       }
 

--- a/.yarn/sdks/typescript/lib/tsserverlibrary.js
+++ b/.yarn/sdks/typescript/lib/tsserverlibrary.js
@@ -61,28 +61,12 @@ const moduleWrapper = tsserver => {
           //
           // Ref: https://github.com/microsoft/vscode/issues/105014#issuecomment-686760910
           //
-          // 2021-10-08: VSCode changed the format in 1.61.
+          // Update Oct 8 2021: VSCode changed their format in 1.61.
           // Before | ^zip:/c:/foo/bar.zip/package.json
-          // After  | ^/zip//c:/foo/bar.zip/package.json
-          //
-          // 2022-04-06: VSCode changed the format in 1.66.
-          // Before | ^/zip//c:/foo/bar.zip/package.json
-          // After  | ^/zip/c:/foo/bar.zip/package.json
-          //
-          // 2022-05-06: VSCode changed the format in 1.68
-          // Before | ^/zip/c:/foo/bar.zip/package.json
           // After  | ^/zip//c:/foo/bar.zip/package.json
           //
           case `vscode <1.61`: {
             str = `^zip:${str}`;
-          } break;
-
-          case `vscode <1.66`: {
-            str = `^/zip/${str}`;
-          } break;
-
-          case `vscode <1.68`: {
-            str = `^/zip${str}`;
           } break;
 
           case `vscode`: {
@@ -135,7 +119,9 @@ const moduleWrapper = tsserver => {
 
       case `vscode`:
       default: {
-        return str.replace(/^\^?(zip:|\/zip(\/ts-nul-authority)?)\/+/, process.platform === `win32` ? `` : `/`)
+        return process.platform === `win32`
+          ? str.replace(/^\^?(zip:|\/zip)\/+/, ``)
+          : str.replace(/^\^?(zip:|\/zip)\/+/, `/`);
       } break;
     }
   }
@@ -174,21 +160,8 @@ const moduleWrapper = tsserver => {
         typeof parsedMessage.arguments.hostInfo === `string`
       ) {
         hostInfo = parsedMessage.arguments.hostInfo;
-        if (hostInfo === `vscode` && process.env.VSCODE_IPC_HOOK) {
-          const [, major, minor] = (process.env.VSCODE_IPC_HOOK.match(
-            // The RegExp from https://semver.org/ but without the caret at the start
-            /(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-          ) ?? []).map(Number)
-
-          if (major === 1) {
-            if (minor < 61) {
-              hostInfo += ` <1.61`;
-            } else if (minor < 66) {
-              hostInfo += ` <1.66`;
-            } else if (minor < 68) {
-              hostInfo += ` <1.68`;
-            }
-          }
+        if (hostInfo === `vscode` && process.env.VSCODE_IPC_HOOK && process.env.VSCODE_IPC_HOOK.match(/Code\/1\.([1-5][0-9]|60)\./)) {
+          hostInfo += ` <1.61`;
         }
       }
 

--- a/.yarn/sdks/typescript/package.json
+++ b/.yarn/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript",
-  "version": "4.7.4-sdk",
+  "version": "4.8.2-sdk",
   "main": "./lib/typescript.js",
   "type": "commonjs"
 }


### PR DESCRIPTION
## Description
This will be a hotfix to add global support for Typescript 4.8.2 in VSCode workspaces. I have tested this locally and remotely in https://github.com/ral-facilities/operationsgateway/pull/68 and https://github.com/ral-facilities/operationsgateway/pull/65. We need all libraries to be up to date to ensure this works.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
Hotfix