### PR TITLE
DSEGOG-62 showing/hiding plot channels

### DIFF
--- a/src/api/records.test.tsx
+++ b/src/api/records.test.tsx
@@ -241,7 +241,10 @@ describe('records api functions', () => {
       });
 
       const { result } = renderHook(
-        () => usePlotRecords('activeArea', ['activeExperiment']),
+        () =>
+          usePlotRecords('activeArea', [
+            { name: 'activeExperiment', options: { visible: true } },
+          ]),
         {
           wrapper: hooksWrapperWithProviders(),
         }

--- a/src/api/records.tsx
+++ b/src/api/records.tsx
@@ -12,6 +12,7 @@ import {
   ScalarChannel,
   SortType,
   WaveformChannel,
+  SelectedPlotChannel,
 } from '../app.types';
 import { useAppSelector } from '../state/hooks';
 import { selectQueryParams } from '../state/slices/searchSlice';
@@ -230,12 +231,14 @@ export const getFormattedAxisData = (
 // eventually they'll be used to query for data
 export const usePlotRecords = (
   XAxis: string,
-  selectedChannels: string[]
+  selectedChannels: SelectedPlotChannel[]
 ): UseQueryResult<PlotDataset[], AxiosError> => {
   const usePlotRecordsOptions = React.useMemo(
     () => ({
       select: (records: Record[]) => {
-        const plotDatasets = selectedChannels.map((plotChannelName) => {
+        const plotDatasets = selectedChannels.map((plotChannel) => {
+          const plotChannelName = plotChannel.name;
+
           // Add the initial entry for dataset called plotChannelName
           // data field is currently empty, the below loop populates it
           const newDataset: PlotDataset = {

--- a/src/app.types.tsx
+++ b/src/app.types.tsx
@@ -164,6 +164,13 @@ export type PlotDataset = {
   }[];
 };
 
+export type SelectedPlotChannel = {
+  name: string;
+  options: {
+    visible: boolean;
+  };
+};
+
 // Update this whenever we have a new icon for a specific column
 export const columnIconMappings = new Map()
   .set('TIMESTAMP', <AccessTime />)

--- a/src/plotting/plot.component.test.tsx
+++ b/src/plotting/plot.component.test.tsx
@@ -144,6 +144,7 @@ describe('plotting', () => {
           }),
         })
       );
+      expect(mockVictoryGroup).toHaveBeenCalled();
       expect(mockVictoryScatter.mock.calls.length).toEqual(
         testPlotDatasets.length
       );
@@ -191,6 +192,7 @@ describe('plotting', () => {
           }),
         })
       );
+      expect(mockVictoryGroup).toHaveBeenCalled();
       expect(mockVictoryScatter.mock.calls.length).toEqual(
         testPlotDatasets.length
       );
@@ -214,6 +216,34 @@ describe('plotting', () => {
           })
         );
       }
+    });
+
+    it('renders no plot if the user has not selected any channels to plot', () => {
+      props.selectedChannels = [];
+
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { default: Plot } = require('./plot.component');
+
+      render(<Plot {...props} />);
+
+      expect(mockVictoryChart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scale: { x: 'time', y: 'linear' },
+        })
+      );
+      expect(mockVictoryLabel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: 'scatter plot',
+        })
+      );
+      expect(mockVictoryLegend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: [],
+        })
+      );
+      expect(mockVictoryGroup).not.toHaveBeenCalled();
+      expect(mockVictoryScatter).not.toHaveBeenCalled();
+      expect(mockVictoryLine).not.toHaveBeenCalled();
     });
 
     it('redraws the plot in response to resize events', () => {

--- a/src/plotting/plot.component.test.tsx
+++ b/src/plotting/plot.component.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { PlotProps, formatTooltipLabel } from './plot.component';
 import { testPlotDatasets } from '../setupTests';
+import { SelectedPlotChannel } from '../app.types';
 
 describe('plotting', () => {
   const mockVictoryChart = jest.fn();
@@ -96,9 +97,21 @@ describe('plotting', () => {
   describe('Plot component', () => {
     let props: PlotProps;
 
+    const selectedChannels: SelectedPlotChannel[] = testPlotDatasets.map(
+      (dataset) => {
+        return {
+          name: dataset.name,
+          options: {
+            visible: true,
+          },
+        };
+      }
+    );
+
     beforeEach(() => {
       props = {
         datasets: testPlotDatasets,
+        selectedChannels,
         title: 'scatter plot',
         type: 'scatter',
         XAxisSettings: { scale: 'time' },

--- a/src/plotting/plot.component.tsx
+++ b/src/plotting/plot.component.tsx
@@ -30,8 +30,8 @@ export const formatTooltipLabel = (
 };
 
 export interface PlotProps {
-  datasets?: PlotDataset[];
-  selectedChannels?: SelectedPlotChannel[];
+  datasets: PlotDataset[];
+  selectedChannels: SelectedPlotChannel[];
   title: string;
   type: PlotType;
   XAxisSettings: XAxisSettings;
@@ -128,8 +128,8 @@ const Plot = (props: PlotProps) => {
               return { name: channel.name, symbol: { fill: '#e31a1c' } };
             })}
         />
-        {selectedChannels?.map((channel) => {
-          const currentDataset = datasets?.find(
+        {selectedChannels.map((channel) => {
+          const currentDataset = datasets.find(
             (dataset) => dataset.name === channel.name
           );
           if (currentDataset) {

--- a/src/plotting/plotSettings.component.test.tsx
+++ b/src/plotting/plotSettings.component.test.tsx
@@ -212,7 +212,14 @@ describe('Plot Settings component', () => {
     fireEvent.keyDown(autocomplete, { key: 'ArrowDown' });
     fireEvent.keyDown(autocomplete, { key: 'Enter' });
 
-    expect(changeSelectedChannels).toHaveBeenCalledWith(['CHANNEL_1']);
+    expect(changeSelectedChannels).toHaveBeenCalledWith([
+      {
+        name: 'CHANNEL_1',
+        options: {
+          visible: true,
+        },
+      },
+    ]);
   });
 
   it('allows user to add channels on the y-axis (mouse and keyboard)', async () => {
@@ -226,7 +233,14 @@ describe('Plot Settings component', () => {
     await user.type(input, 'CHANNEL');
     await user.click(screen.getByText('CHANNEL_1'));
 
-    expect(changeSelectedChannels).toHaveBeenCalledWith(['CHANNEL_1']);
+    expect(changeSelectedChannels).toHaveBeenCalledWith([
+      {
+        name: 'CHANNEL_1',
+        options: {
+          visible: true,
+        },
+      },
+    ]);
   });
 
   it('changes scale to time automatically if time is selected as x-axis', async () => {
@@ -259,8 +273,49 @@ describe('Plot Settings component', () => {
     });
   });
 
+  it('allows user to toggle visibility of a selected channel', async () => {
+    props.selectedChannels = [
+      {
+        name: 'CHANNEL_1',
+        options: {
+          visible: true,
+        },
+      },
+    ];
+    createView();
+
+    await user.click(screen.getByRole('tab', { name: 'Y' }));
+
+    await user.click(screen.getByLabelText('Toggle CHANNEL_1 visibility off'));
+    expect(changeSelectedChannels).toHaveBeenLastCalledWith([
+      {
+        name: 'CHANNEL_1',
+        options: {
+          visible: false,
+        },
+      },
+    ]);
+
+    await user.click(screen.getByLabelText('Toggle CHANNEL_1 visibility on'));
+    expect(changeSelectedChannels).toHaveBeenLastCalledWith([
+      {
+        name: 'CHANNEL_1',
+        options: {
+          visible: true,
+        },
+      },
+    ]);
+  });
+
   it('removes channel from display when we click Close on its label', async () => {
-    props.selectedChannels = ['shotnum'];
+    props.selectedChannels = [
+      {
+        name: 'shotnum',
+        options: {
+          visible: true,
+        },
+      },
+    ];
     createView();
 
     await user.click(screen.getByRole('tab', { name: 'Y' }));

--- a/src/plotting/plotSettings.component.test.tsx
+++ b/src/plotting/plotSettings.component.test.tsx
@@ -289,6 +289,12 @@ describe('Plot Settings component', () => {
       {
         name: 'CHANNEL_1',
         options: {
+          visible: true,
+        },
+      },
+      {
+        name: 'CHANNEL_2',
+        options: {
           visible: false,
         },
       },
@@ -297,10 +303,16 @@ describe('Plot Settings component', () => {
 
     await user.click(screen.getByRole('tab', { name: 'Y' }));
 
-    await user.click(screen.getByLabelText('Toggle CHANNEL_1 visibility on'));
+    await user.click(screen.getByLabelText('Toggle CHANNEL_2 visibility on'));
     expect(changeSelectedChannels).toHaveBeenLastCalledWith([
       {
         name: 'CHANNEL_1',
+        options: {
+          visible: true,
+        },
+      },
+      {
+        name: 'CHANNEL_2',
         options: {
           visible: true,
         },
@@ -312,7 +324,7 @@ describe('Plot Settings component', () => {
     props.XAxis = 'timestamp';
     createView();
 
-    await user.click(screen.getByLabelText('Remove timestamp axis'));
+    await user.click(screen.getByLabelText('Remove timestamp from x-axis'));
     expect(changeXAxis).toHaveBeenLastCalledWith('');
     expect(changeXAxisSettings).toHaveBeenCalledWith({
       ...props.XAxisSettings,
@@ -323,7 +335,13 @@ describe('Plot Settings component', () => {
   it('removes channel from display when we click Close on its label', async () => {
     props.selectedChannels = [
       {
-        name: 'shotnum',
+        name: 'CHANNEL_1',
+        options: {
+          visible: true,
+        },
+      },
+      {
+        name: 'CHANNEL_2',
         options: {
           visible: true,
         },
@@ -333,7 +351,32 @@ describe('Plot Settings component', () => {
 
     await user.click(screen.getByRole('tab', { name: 'Y' }));
 
-    await user.click(screen.getByLabelText('Remove shotnum axis'));
+    await user.click(screen.getByLabelText('Remove CHANNEL_1 from y-axis'));
+    expect(changeSelectedChannels).toHaveBeenLastCalledWith([
+      {
+        name: 'CHANNEL_2',
+        options: {
+          visible: true,
+        },
+      },
+    ]);
+    expect(changeYAxesSettings).not.toHaveBeenCalled();
+  });
+
+  it('removes channel from display when we click Close on its label and resets y-axis scale to linear if no selected channels remain', async () => {
+    props.selectedChannels = [
+      {
+        name: 'CHANNEL_1',
+        options: {
+          visible: true,
+        },
+      },
+    ];
+    createView();
+
+    await user.click(screen.getByRole('tab', { name: 'Y' }));
+
+    await user.click(screen.getByLabelText('Remove CHANNEL_1 from y-axis'));
     expect(changeSelectedChannels).toHaveBeenLastCalledWith([]);
     expect(changeYAxesSettings).toHaveBeenCalledWith({
       ...props.YAxesSettings,

--- a/src/plotting/plotSettings.component.test.tsx
+++ b/src/plotting/plotSettings.component.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { fireEvent, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import PlotSettings, { PlotSettingsProps } from './plotSettings.component';
 import userEvent from '@testing-library/user-event';
-import { renderComponentWithProviders } from '../setupTests';
 import { FullScalarChannelMetadata } from '../app.types';
 
 describe('Plot Settings component', () => {
@@ -16,7 +15,7 @@ describe('Plot Settings component', () => {
   const changeSelectedChannels = jest.fn();
 
   const createView = () => {
-    return renderComponentWithProviders(<PlotSettings {...props} />);
+    return render(<PlotSettings {...props} />);
   };
 
   const channels: FullScalarChannelMetadata[] = [
@@ -261,19 +260,7 @@ describe('Plot Settings component', () => {
     });
   });
 
-  it('removes x-axis from display when we click Close on its label', async () => {
-    props.XAxis = 'timestamp';
-    createView();
-
-    await user.click(screen.getByLabelText('Remove timestamp axis'));
-    expect(changeXAxis).toHaveBeenLastCalledWith('');
-    expect(changeXAxisSettings).toHaveBeenCalledWith({
-      ...props.XAxisSettings,
-      scale: 'linear',
-    });
-  });
-
-  it('allows user to toggle visibility of a selected channel', async () => {
+  it('allows user to toggle visibility of a selected channel off', async () => {
     props.selectedChannels = [
       {
         name: 'CHANNEL_1',
@@ -295,6 +282,20 @@ describe('Plot Settings component', () => {
         },
       },
     ]);
+  });
+
+  it('allows user to toggle visibility of a selected channel on', async () => {
+    props.selectedChannels = [
+      {
+        name: 'CHANNEL_1',
+        options: {
+          visible: false,
+        },
+      },
+    ];
+    createView();
+
+    await user.click(screen.getByRole('tab', { name: 'Y' }));
 
     await user.click(screen.getByLabelText('Toggle CHANNEL_1 visibility on'));
     expect(changeSelectedChannels).toHaveBeenLastCalledWith([
@@ -305,6 +306,18 @@ describe('Plot Settings component', () => {
         },
       },
     ]);
+  });
+
+  it('removes x-axis from display when we click Close on its label', async () => {
+    props.XAxis = 'timestamp';
+    createView();
+
+    await user.click(screen.getByLabelText('Remove timestamp axis'));
+    expect(changeXAxis).toHaveBeenLastCalledWith('');
+    expect(changeXAxisSettings).toHaveBeenCalledWith({
+      ...props.XAxisSettings,
+      scale: 'linear',
+    });
   });
 
   it('removes channel from display when we click Close on its label', async () => {

--- a/src/plotting/plotSettings.component.tsx
+++ b/src/plotting/plotSettings.component.tsx
@@ -422,7 +422,9 @@ const PlotSettings = (props: PlotSettingsProps) => {
                     padding: 1,
                   }}
                 >
-                  <Typography noWrap>{XAxis}</Typography>
+                  <Typography maxWidth="240" noWrap>
+                    {XAxis}
+                  </Typography>
                   <StyledClose
                     aria-label={`Remove ${XAxis} from x-axis`}
                     onClick={() => handleXAxisChange('')}
@@ -543,7 +545,9 @@ const PlotSettings = (props: PlotSettingsProps) => {
                     padding: 1,
                   }}
                 >
-                  <Typography noWrap>{plotChannel.name}</Typography>
+                  <Typography maxWidth="205" noWrap>
+                    {plotChannel.name}
+                  </Typography>
                   <Box
                     sx={{
                       display: 'flex',

--- a/src/plotting/plotSettings.component.tsx
+++ b/src/plotting/plotSettings.component.tsx
@@ -44,17 +44,11 @@ const StyledClose = styled(Close)(() => ({
 const StyledVisibility = styled(Visibility)(() => ({
   cursor: 'pointer',
   color: 'black',
-  '&:hover': {
-    color: 'red',
-  },
 }));
 
 const StyledVisibilityOff = styled(VisibilityOff)(() => ({
   cursor: 'pointer',
   color: 'black',
-  '&:hover': {
-    color: 'green',
-  },
 }));
 
 type TabValue = 'X' | 'Y';
@@ -212,7 +206,7 @@ const PlotSettings = (props: PlotSettingsProps) => {
   const removePlotChannel = React.useCallback(
     (channelName: string) => {
       const newSelectedChannelsArray = selectedChannels.filter(
-        (channel) => channel.name === channelName
+        (channel) => channel.name !== channelName
       );
       changeSelectedChannels(newSelectedChannelsArray);
       if (newSelectedChannelsArray.length === 0) {

--- a/src/plotting/plotSettings.component.tsx
+++ b/src/plotting/plotSettings.component.tsx
@@ -565,7 +565,7 @@ const PlotSettings = (props: PlotSettingsProps) => {
                     ) : (
                       <IconButton
                         color="primary"
-                        aria-label={`Toggle ${plotChannel.name} visibility off`}
+                        aria-label={`Toggle ${plotChannel.name} visibility on`}
                         size="small"
                         sx={{ paddingTop: '0', paddingBottom: '0' }}
                         onClick={() =>

--- a/src/plotting/plotSettings.component.tsx
+++ b/src/plotting/plotSettings.component.tsx
@@ -553,21 +553,32 @@ const PlotSettings = (props: PlotSettingsProps) => {
                   }}
                 >
                   <Typography noWrap>{plotChannel.name}</Typography>
-                  {plotChannel.options.visible ? (
-                    <StyledVisibility
-                      aria-label={`Toggle ${plotChannel.name} visibility off`}
-                      onClick={() => toggleChannelVisibility(plotChannel.name)}
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      flexDirection: 'row',
+                    }}
+                  >
+                    {plotChannel.options.visible ? (
+                      <StyledVisibility
+                        aria-label={`Toggle ${plotChannel.name} visibility off`}
+                        onClick={() =>
+                          toggleChannelVisibility(plotChannel.name)
+                        }
+                      />
+                    ) : (
+                      <StyledVisibilityOff
+                        aria-label={`Toggle ${plotChannel.name} visibility on`}
+                        onClick={() =>
+                          toggleChannelVisibility(plotChannel.name)
+                        }
+                      />
+                    )}
+                    <StyledClose
+                      aria-label={`Remove ${plotChannel.name} axis`}
+                      onClick={() => removePlotChannel(plotChannel.name)}
                     />
-                  ) : (
-                    <StyledVisibilityOff
-                      aria-label={`Toggle ${plotChannel.name} visibility on`}
-                      onClick={() => toggleChannelVisibility(plotChannel.name)}
-                    />
-                  )}
-                  <StyledClose
-                    aria-label={`Remove ${plotChannel.name} axis`}
-                    onClick={() => removePlotChannel(plotChannel.name)}
-                  />
+                  </Box>
                 </Box>
               </Grid>
             ))}

--- a/src/plotting/plotSettings.component.tsx
+++ b/src/plotting/plotSettings.component.tsx
@@ -127,8 +127,8 @@ const PlotSettings = (props: PlotSettingsProps) => {
   );
 
   const handleChangeChartType = React.useCallback(
-    (event: React.MouseEvent<HTMLElement>, newChartType: PlotType | null) => {
-      changePlotType(newChartType ?? 'scatter');
+    (event: React.MouseEvent<HTMLElement>, newChartType: PlotType) => {
+      changePlotType(newChartType);
     },
     [changePlotType]
   );
@@ -424,7 +424,7 @@ const PlotSettings = (props: PlotSettingsProps) => {
                 >
                   <Typography noWrap>{XAxis}</Typography>
                   <StyledClose
-                    aria-label={`Remove ${XAxis} axis`}
+                    aria-label={`Remove ${XAxis} from x-axis`}
                     onClick={() => handleXAxisChange('')}
                   />
                 </Box>
@@ -576,7 +576,7 @@ const PlotSettings = (props: PlotSettingsProps) => {
                       </IconButton>
                     )}
                     <StyledClose
-                      aria-label={`Remove ${plotChannel.name} axis`}
+                      aria-label={`Remove ${plotChannel.name} from y-axis`}
                       onClick={() => removePlotChannel(plotChannel.name)}
                     />
                   </Box>

--- a/src/plotting/plotSettings.component.tsx
+++ b/src/plotting/plotSettings.component.tsx
@@ -16,6 +16,7 @@ import {
   InputAdornment,
   Autocomplete,
   Typography,
+  IconButton,
 } from '@mui/material';
 import {
   ScatterPlot,
@@ -39,16 +40,6 @@ const StyledClose = styled(Close)(() => ({
   '&:hover': {
     color: 'red',
   },
-}));
-
-const StyledVisibility = styled(Visibility)(() => ({
-  cursor: 'pointer',
-  color: 'black',
-}));
-
-const StyledVisibilityOff = styled(VisibilityOff)(() => ({
-  cursor: 'pointer',
-  color: 'black',
 }));
 
 type TabValue = 'X' | 'Y';
@@ -560,19 +551,29 @@ const PlotSettings = (props: PlotSettingsProps) => {
                     }}
                   >
                     {plotChannel.options.visible ? (
-                      <StyledVisibility
+                      <IconButton
+                        color="primary"
                         aria-label={`Toggle ${plotChannel.name} visibility off`}
+                        size="small"
+                        sx={{ paddingTop: '0', paddingBottom: '0' }}
                         onClick={() =>
                           toggleChannelVisibility(plotChannel.name)
                         }
-                      />
+                      >
+                        <Visibility sx={{ color: 'black' }} />
+                      </IconButton>
                     ) : (
-                      <StyledVisibilityOff
-                        aria-label={`Toggle ${plotChannel.name} visibility on`}
+                      <IconButton
+                        color="primary"
+                        aria-label={`Toggle ${plotChannel.name} visibility off`}
+                        size="small"
+                        sx={{ paddingTop: '0', paddingBottom: '0' }}
                         onClick={() =>
                           toggleChannelVisibility(plotChannel.name)
                         }
-                      />
+                      >
+                        <VisibilityOff sx={{ color: 'black' }} />
+                      </IconButton>
                     )}
                     <StyledClose
                       aria-label={`Remove ${plotChannel.name} axis`}

--- a/src/plotting/plotWindow.component.tsx
+++ b/src/plotting/plotWindow.component.tsx
@@ -178,7 +178,7 @@ const PlotWindow = (props: PlotWindowProps) => {
             </Grid>
           </Grid>
           <Plot
-            datasets={records}
+            datasets={records ?? []}
             selectedChannels={selectedChannels}
             title={plotTitle || untitledTitle}
             type={plotType}

--- a/src/plotting/plotWindow.component.tsx
+++ b/src/plotting/plotWindow.component.tsx
@@ -179,6 +179,7 @@ const PlotWindow = (props: PlotWindowProps) => {
           </Grid>
           <Plot
             datasets={records}
+            selectedChannels={selectedChannels}
             title={plotTitle || untitledTitle}
             type={plotType}
             XAxis={XAxis}

--- a/src/plotting/plotWindow.component.tsx
+++ b/src/plotting/plotWindow.component.tsx
@@ -13,7 +13,12 @@ import {
 } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
-import { XAxisSettings, YAxisSettings, PlotType } from '../app.types';
+import {
+  XAxisSettings,
+  YAxisSettings,
+  PlotType,
+  SelectedPlotChannel,
+} from '../app.types';
 import { usePlotRecords } from '../api/records';
 import { useScalarChannels } from '../api/channels';
 import PlotWindowPortal from './plotWindowPortal.component';
@@ -35,7 +40,9 @@ const PlotWindow = (props: PlotWindowProps) => {
     scale: 'linear',
   });
   const [XAxis, setXAxis] = React.useState<string>('');
-  const [selectedChannels, setSelectedChannels] = React.useState<string[]>([]);
+  const [selectedChannels, setSelectedChannels] = React.useState<
+    SelectedPlotChannel[]
+  >([]);
 
   const [open, setOpen] = React.useState(true);
   const handleDrawerOpen = React.useCallback(() => {

--- a/src/plotting/plotWindow.component.tsx
+++ b/src/plotting/plotWindow.component.tsx
@@ -106,6 +106,9 @@ const PlotWindow = (props: PlotWindowProps) => {
                 <IconButton
                   onClick={handleDrawerClose}
                   aria-label="close settings"
+                  sx={{
+                    ...(!open && { visibility: 'hidden' }),
+                  }}
                 >
                   <ChevronLeftIcon />
                 </IconButton>


### PR DESCRIPTION
## Description
This allows the user to toggle the visibility of a plotted data channel in the plot by toggling a button in its channel label. Note this does not remove the plotted data from the plot - it only toggles its opacity and removes its label from the legend, thus keeping the plot scales the same.

This attempts to replicate the behaviour in eCat. If a channel's visibility is toggled off and we export to SVG, it will export exactly what is shown in the plot, i.e. minus the channel's data. If we export the plot data, all the data in the plot will be exported, including hidden channels. This is the same as in eCat but can be changed if we want to.

## Testing instructions
Use the visibility toggle to show/hide channels in the plot. Try exporting data to test the expected results.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes DSEGOG-62