### PR TITLE
DSEGOG-88 data refresh button

### DIFF
--- a/cypress/integration/table/search.spec.ts
+++ b/cypress/integration/table/search.spec.ts
@@ -79,9 +79,7 @@ describe('Search', () => {
 
   describe('searches by relative timeframe', () => {
     beforeEach(() => {
-      cy.clock();
-      // Advance date to 1970-01-08 01:00:00
-      cy.tick(1000 * 60 * 60 * 24 * 7);
+      cy.clock(new Date('1970-01-08 01:00:00'));
     });
 
     it('last 10 minutes', () => {
@@ -267,9 +265,7 @@ describe('Search', () => {
 
   describe('searches by custom timeframe', () => {
     beforeEach(() => {
-      cy.clock();
-      // Advance date to 1970-01-08 01:00:00
-      cy.tick(1000 * 60 * 60 * 24 * 7);
+      cy.clock(new Date('1970-01-08 01:00:00'));
     });
 
     it('last 5 minutes', () => {

--- a/cypress/support/util.js
+++ b/cypress/support/util.js
@@ -60,7 +60,7 @@ export function getDraggableSelector(draggableId) {
 
 export const formatDateTimeForApi = (datetime) => {
   const dateString = format(datetime, 'yyyy-MM-dd');
-  const timeString = format(datetime, 'HH:mm');
+  const timeString = format(datetime, 'HH:mm:ss');
 
   return `${dateString}T${timeString}`;
 };

--- a/src/search/components/__snapshots__/dataRefresh.component.test.tsx.snap
+++ b/src/search/components/__snapshots__/dataRefresh.component.test.tsx.snap
@@ -3,39 +3,34 @@
 exports[`DataRefresh renders correctly 1`] = `
 <DocumentFragment>
   <div
-    class="MuiBox-root css-79elbk"
+    class="MuiBox-root css-12b4m5q"
   >
-    <div
-      aria-label="select max shots to display"
-      class="MuiBox-root css-1hqcbhu"
+    <button
+      aria-label="Refresh data"
+      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall css-1knaqv7-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="button"
     >
-      <button
-        aria-label="Refresh data"
-        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall css-1knaqv7-MuiButtonBase-root-MuiButton-root"
-        tabindex="0"
-        type="button"
+      <span
+        class="MuiButton-startIcon MuiButton-iconSizeSmall css-y6rp3m-MuiButton-startIcon"
       >
-        <span
-          class="MuiButton-startIcon MuiButton-iconSizeSmall css-y6rp3m-MuiButton-startIcon"
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+          data-testid="RefreshIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
         >
-          <svg
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
-            data-testid="RefreshIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
-            />
-          </svg>
-        </span>
-        Refresh
-        <span
-          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
-        />
-      </button>
-    </div>
+          <path
+            d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+          />
+        </svg>
+      </span>
+      Refresh
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
   </div>
 </DocumentFragment>
 `;

--- a/src/search/components/__snapshots__/dataRefresh.component.test.tsx.snap
+++ b/src/search/components/__snapshots__/dataRefresh.component.test.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DataRefresh renders correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-79elbk"
+  >
+    <div
+      aria-label="select max shots to display"
+      class="MuiBox-root css-1hqcbhu"
+    >
+      <button
+        aria-label="Refresh data"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall css-1knaqv7-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-startIcon MuiButton-iconSizeSmall css-y6rp3m-MuiButton-startIcon"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+            data-testid="RefreshIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+            />
+          </svg>
+        </span>
+        Refresh
+        <span
+          class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+        />
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/search/components/dataRefresh.component.test.tsx
+++ b/src/search/components/dataRefresh.component.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import DataRefresh, { type DataRefreshProps } from './dataRefresh.component';
+import { render, screen, type RenderResult } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+describe('DataRefresh', () => {
+  let props: DataRefreshProps;
+  const refreshData = jest.fn();
+
+  const createView = (): RenderResult => {
+    return render(<DataRefresh {...props} />);
+  };
+
+  beforeEach(() => {
+    props = {
+      timeframeSet: true,
+      refreshData,
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly', () => {
+    const { asFragment } = createView();
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('is disabled and does not call refreshData on click if no timeframe is currently set', async () => {
+    props.timeframeSet = false;
+    createView();
+
+    const button = screen.getByRole('button', { name: 'Refresh data' });
+    expect(button).toBeDisabled();
+  });
+
+  it('calls refreshData on click if timeframe set', async () => {
+    const user = userEvent.setup();
+    createView();
+
+    const button = screen.getByRole('button', { name: 'Refresh data' });
+    await user.click(button);
+    expect(refreshData).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/search/components/dataRefresh.component.tsx
+++ b/src/search/components/dataRefresh.component.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Box, Button } from '@mui/material';
+import { Refresh } from '@mui/icons-material';
+
+export interface DataRefreshProps {
+  refreshData: () => void;
+}
+
+const DataRefresh = (props: DataRefreshProps) => {
+  const { refreshData } = props;
+
+  return (
+    <Box sx={{ position: 'relative' }}>
+      <Box
+        aria-label="select max shots to display"
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+          paddingRight: 5,
+          overflow: 'hidden',
+        }}
+      >
+        <Button
+          startIcon={<Refresh />}
+          onClick={refreshData}
+          size="small"
+          aria-label="Refresh data"
+        >
+          Refresh
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+
+DataRefresh.displayName = 'DataRefresh';
+
+export default DataRefresh;

--- a/src/search/components/dataRefresh.component.tsx
+++ b/src/search/components/dataRefresh.component.tsx
@@ -3,32 +3,31 @@ import { Box, Button } from '@mui/material';
 import { Refresh } from '@mui/icons-material';
 
 export interface DataRefreshProps {
+  timeframeSet: boolean;
   refreshData: () => void;
 }
 
 const DataRefresh = (props: DataRefreshProps) => {
-  const { refreshData } = props;
+  const { timeframeSet, refreshData } = props;
 
   return (
-    <Box sx={{ position: 'relative' }}>
-      <Box
-        aria-label="select max shots to display"
-        sx={{
-          display: 'flex',
-          flexDirection: 'row',
-          paddingRight: 5,
-          overflow: 'hidden',
-        }}
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'row',
+        marginTop: '6px',
+        overflow: 'hidden',
+      }}
+    >
+      <Button
+        disabled={!timeframeSet}
+        startIcon={<Refresh />}
+        onClick={refreshData}
+        size="small"
+        aria-label="Refresh data"
       >
-        <Button
-          startIcon={<Refresh />}
-          onClick={refreshData}
-          size="small"
-          aria-label="Refresh data"
-        >
-          Refresh
-        </Button>
-      </Box>
+        Refresh
+      </Button>
     </Box>
   );
 };

--- a/src/search/searchBar.component.test.tsx
+++ b/src/search/searchBar.component.test.tsx
@@ -110,7 +110,7 @@ describe('searchBar component', () => {
 
     beforeEach(() => {
       // Mock the Date constructor to allow for accurate comparison between expected and actual dates
-      const testDate = new Date('2022-01-01 00:00:00');
+      const testDate = new Date('2022-01-11 12:00:00');
       realDate = Date;
       global.Date = class extends Date {
         constructor(date) {
@@ -135,9 +135,8 @@ describe('searchBar component', () => {
       await user.click(
         within(timeframePopup).getByRole('button', { name: 'Last 10 mins' })
       );
-      const expectedToDate = new Date();
-      const expectedFromDate = new Date(expectedToDate);
-      expectedFromDate.setMinutes(expectedToDate.getMinutes() - 10);
+      const expectedToDate = new Date('2022-01-11 12:00:00');
+      const expectedFromDate = new Date('2022-01-11 11:50:00');
       await user.click(screen.getByLabelText('close timeframe search box'));
       await user.click(screen.getByRole('button', { name: 'Search' }));
 
@@ -148,8 +147,8 @@ describe('searchBar component', () => {
       expect(actualFromDate).toBeDefined();
       expect(actualToDate).toBeDefined();
 
-      expect(formatDateTimeForApi(expectedFromDate)).toEqual(actualFromDate);
-      expect(formatDateTimeForApi(expectedToDate)).toEqual(actualToDate);
+      expect(actualFromDate).toEqual(formatDateTimeForApi(expectedFromDate));
+      expect(actualToDate).toEqual(formatDateTimeForApi(expectedToDate));
     });
 
     it('hours', async () => {
@@ -161,9 +160,8 @@ describe('searchBar component', () => {
       await user.click(
         within(timeframePopup).getByRole('button', { name: 'Last 24 hours' })
       );
-      const expectedToDate = new Date();
-      const expectedFromDate = new Date(expectedToDate);
-      expectedFromDate.setHours(expectedToDate.getHours() - 24);
+      const expectedToDate = new Date('2022-01-11 12:00:00');
+      const expectedFromDate = new Date('2022-01-10 12:00:00');
       await user.click(screen.getByLabelText('close timeframe search box'));
       await user.click(screen.getByRole('button', { name: 'Search' }));
 
@@ -174,8 +172,8 @@ describe('searchBar component', () => {
       expect(actualFromDate).toBeDefined();
       expect(actualToDate).toBeDefined();
 
-      expect(formatDateTimeForApi(expectedFromDate)).toEqual(actualFromDate);
-      expect(formatDateTimeForApi(expectedToDate)).toEqual(actualToDate);
+      expect(actualFromDate).toEqual(formatDateTimeForApi(expectedFromDate));
+      expect(actualToDate).toEqual(formatDateTimeForApi(expectedToDate));
     });
 
     it('days', async () => {
@@ -187,9 +185,8 @@ describe('searchBar component', () => {
       await user.click(
         within(timeframePopup).getByRole('button', { name: 'Last 7 days' })
       );
-      const expectedToDate = new Date();
-      const expectedFromDate = new Date(expectedToDate);
-      expectedFromDate.setDate(expectedToDate.getDate() - 7);
+      const expectedToDate = new Date('2022-01-11 12:00:00');
+      const expectedFromDate = new Date('2022-01-04 12:00:00');
       await user.click(screen.getByLabelText('close timeframe search box'));
       await user.click(screen.getByRole('button', { name: 'Search' }));
 
@@ -200,8 +197,62 @@ describe('searchBar component', () => {
       expect(actualFromDate).toBeDefined();
       expect(actualToDate).toBeDefined();
 
-      expect(formatDateTimeForApi(expectedFromDate)).toEqual(actualFromDate);
-      expect(formatDateTimeForApi(expectedToDate)).toEqual(actualToDate);
+      expect(actualFromDate).toEqual(formatDateTimeForApi(expectedFromDate));
+      expect(actualToDate).toEqual(formatDateTimeForApi(expectedToDate));
+    });
+
+    it('refreshes datetime stamps and launches search if timeframe is set and refresh button clicked', async () => {
+      const state = getInitialState();
+      const { store } = createView(state);
+
+      await user.click(screen.getByLabelText('open timeframe search box'));
+      const timeframePopup = screen.getByRole('dialog');
+      await user.click(
+        within(timeframePopup).getByRole('button', {
+          name: 'Last 10 mins',
+        })
+      );
+      const expectedToDate = new Date('2022-01-11 12:00:00');
+      const expectedFromDate = new Date('2022-01-11 11:50:00');
+      await user.click(screen.getByLabelText('close timeframe search box'));
+      await user.click(screen.getByRole('button', { name: 'Search' }));
+
+      const actualFromDate =
+        store.getState().search.searchParams.dateRange.fromDate;
+      const actualToDate =
+        store.getState().search.searchParams.dateRange.toDate;
+      expect(actualFromDate).toBeDefined();
+      expect(actualToDate).toBeDefined();
+
+      expect(actualFromDate).toEqual(formatDateTimeForApi(expectedFromDate));
+      expect(actualToDate).toEqual(formatDateTimeForApi(expectedToDate));
+
+      const testDate = new Date('2022-01-11 12:01:00');
+      realDate = Date;
+      global.Date = class extends Date {
+        constructor(date) {
+          if (date) {
+            return super(date);
+          }
+          return testDate;
+        }
+      };
+
+      await user.click(screen.getByRole('button', { name: 'Refresh data' }));
+      const newExpectedToDate = new Date('2022-01-11 12:01:00');
+      const newExpectedFromDate = new Date('2022-01-11 11:51:00');
+
+      const newActualFromDate =
+        store.getState().search.searchParams.dateRange.fromDate;
+      const newActualToDate =
+        store.getState().search.searchParams.dateRange.toDate;
+      expect(newActualFromDate).toBeDefined();
+      expect(newActualToDate).toBeDefined();
+
+      expect(newActualFromDate).toEqual(
+        formatDateTimeForApi(newExpectedFromDate)
+      );
+      expect(newActualToDate).toEqual(formatDateTimeForApi(newExpectedToDate));
     });
   });
 

--- a/src/search/searchBar.component.test.tsx
+++ b/src/search/searchBar.component.test.tsx
@@ -205,6 +205,8 @@ describe('searchBar component', () => {
       const state = getInitialState();
       const { store } = createView(state);
 
+      // Set a relative timestamp and verify the initial seach is correct
+
       await user.click(screen.getByLabelText('open timeframe search box'));
       const timeframePopup = screen.getByRole('dialog');
       await user.click(
@@ -227,6 +229,8 @@ describe('searchBar component', () => {
       expect(actualFromDate).toEqual(formatDateTimeForApi(expectedFromDate));
       expect(actualToDate).toEqual(formatDateTimeForApi(expectedToDate));
 
+      // Mock a new date constructor to simulate time moving forward a minute
+
       const testDate = new Date('2022-01-11 12:01:00');
       realDate = Date;
       global.Date = class extends Date {
@@ -248,6 +252,8 @@ describe('searchBar component', () => {
         store.getState().search.searchParams.dateRange.toDate;
       expect(newActualFromDate).toBeDefined();
       expect(newActualToDate).toBeDefined();
+
+      // Check that the new datetime stamps have each moved forward a minute
 
       expect(newActualFromDate).toEqual(
         formatDateTimeForApi(newExpectedFromDate)

--- a/src/search/searchBar.component.tsx
+++ b/src/search/searchBar.component.tsx
@@ -6,6 +6,7 @@ import Timeframe, {
 import Experiment from './components/experiment.component';
 import ShotNumber from './components/shotNumber.component';
 import MaxShots from './components/maxShots.component';
+import DataRefresh from './components/dataRefresh.component';
 import { Grid, Button, Collapse } from '@mui/material';
 import { useAppSelector, useAppDispatch } from '../state/hooks';
 import { DateRange, SearchParams, ShotnumRange } from '../app.types';
@@ -138,6 +139,11 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
     searchParameterToDate,
   ]);
 
+  const refreshData = React.useCallback(() => {
+    setRelativeTimeframe(timeframeRange);
+    handleSearch();
+  }, [handleSearch, setRelativeTimeframe, timeframeRange]);
+
   const { expanded } = props;
 
   return (
@@ -183,8 +189,13 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
               </Grid>
             </Grid>
           </Grid>
-          <Grid item>
-            <MaxShots maxShots={maxShots} changeMaxShots={setMaxShots} />
+          <Grid container spacing={1} direction="row">
+            <Grid item>
+              <MaxShots maxShots={maxShots} changeMaxShots={setMaxShots} />
+            </Grid>
+            <Grid item>
+              <DataRefresh refreshData={refreshData} />
+            </Grid>
           </Grid>
         </Grid>
       </Grid>

--- a/src/search/searchBar.component.tsx
+++ b/src/search/searchBar.component.tsx
@@ -139,10 +139,19 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
     searchParameterToDate,
   ]);
 
-  const refreshData = React.useCallback(() => {
+  const [refreshingData, setRefreshingData] = React.useState<boolean>(false);
+
+  const refreshData = () => {
     setRelativeTimeframe(timeframeRange);
-    handleSearch();
-  }, [handleSearch, setRelativeTimeframe, timeframeRange]);
+    setRefreshingData(true);
+  };
+
+  React.useEffect(() => {
+    if (refreshingData) {
+      handleSearch();
+      setRefreshingData(false);
+    }
+  }, [handleSearch, refreshingData]);
 
   const { expanded } = props;
 
@@ -189,12 +198,15 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
               </Grid>
             </Grid>
           </Grid>
-          <Grid container spacing={1} direction="row">
+          <Grid container direction="row">
             <Grid item>
               <MaxShots maxShots={maxShots} changeMaxShots={setMaxShots} />
             </Grid>
             <Grid item>
-              <DataRefresh refreshData={refreshData} />
+              <DataRefresh
+                timeframeSet={!!timeframeRange}
+                refreshData={refreshData}
+              />
             </Grid>
           </Grid>
         </Grid>


### PR DESCRIPTION
## Description
This adds a button to refresh the data in the table (and plot) based on what the currently-set timestamp is. If no timestamp is set, the refresh button is disabled. Upon clicking it, the timestamps are updated and the search is relaunched.

## Testing instructions
Test that clicking the button updates datetime stamps and launches search with new parameters.

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [x] {more steps here}

## Agile board tracking
Closes DSEGOG-88