### PR TITLE
DSEGOG-140 Channel tree child selection indicators

### DIFF
--- a/cypress/integration/table/channels.spec.ts
+++ b/cypress/integration/table/channels.spec.ts
@@ -31,25 +31,36 @@ describe('Data Channels Component', () => {
     cy.contains('system').click();
 
     cy.findByRole('checkbox', { name: 'Shot Number' }).check();
+    cy.findByRole('checkbox', { name: 'Active Area' }).check();
+    cy.findByRole('checkbox', { name: 'Active Experiment' }).check();
 
     cy.contains('Add Channels').click();
 
     cy.findByRole('columnheader', { name: 'Shot Number' }).should('be.visible');
+    cy.findByRole('columnheader', { name: 'Active Area' }).should('be.visible');
+    cy.findByRole('columnheader', { name: 'Active Experiment' }).should(
+      'be.visible'
+    );
 
     cy.contains('Data Channels').click();
+    cy.contains('All Channels').click();
+    cy.findByRole('checkbox', { name: 'system' }).should('be.checked');
+    cy.contains('system').click();
 
     cy.findByRole('checkbox', { name: 'Shot Number' }).uncheck();
-
-    cy.findByRole('checkbox', { name: 'Active Area' }).check();
 
     cy.contains('Add Channels').click();
 
     cy.findByRole('columnheader', { name: 'Shot Number' }).should('not.exist');
-    cy.findByRole('columnheader', { name: 'Active Area' }).should('be.visible');
   });
 
   it('lets a user navigate the channel tree', () => {
     cy.contains('Data Channels').click();
+
+    cy.findByRole('checkbox', { name: 'system' }).should(
+      'have.prop',
+      'indeterminate'
+    );
 
     cy.contains('system').click();
 
@@ -60,14 +71,20 @@ describe('Data Channels Component', () => {
     cy.findByRole('button', { name: 'Channels' }).click();
 
     cy.findByRole('button', { name: '1' }).should('be.visible');
+    cy.findByRole('checkbox', { name: '1' }).should('not.be.checked');
 
     cy.findByRole('button', { name: '1' }).click();
 
     cy.contains('Channel_ABCDE').should('be.visible');
+    cy.findByRole('checkbox', { name: 'Channel_ABCDE' }).check();
 
     cy.findByRole('link', { name: 'Channels' }).click();
 
     cy.findByRole('button', { name: '1' }).should('be.visible');
+    cy.findByRole('checkbox', { name: '1' }).should(
+      'have.prop',
+      'indeterminate'
+    );
 
     cy.findByRole('button', { name: '2' }).click();
 
@@ -76,6 +93,10 @@ describe('Data Channels Component', () => {
     cy.contains('All Channels').click();
 
     cy.contains('system').should('be.visible');
+    cy.findByRole('checkbox', { name: 'Channels' }).should(
+      'have.prop',
+      'indeterminate'
+    );
   });
 
   it('displays channel metadata when user clicks on a channel', () => {

--- a/src/channels/__snapshots__/channelTree.component.test.tsx.snap
+++ b/src/channels/__snapshots__/channelTree.component.test.tsx.snap
@@ -18,25 +18,25 @@ exports[`Channel Tree should render correctly for root 1`] = `
         >
           <span
             aria-disabled="true"
-            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary Mui-disabled PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary Mui-disabled MuiCheckbox-root MuiCheckbox-colorPrimary css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-indeterminate MuiCheckbox-colorPrimary Mui-disabled PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-indeterminate MuiCheckbox-colorPrimary Mui-disabled MuiCheckbox-root MuiCheckbox-indeterminate MuiCheckbox-colorPrimary css-12wnr2w-MuiButtonBase-root-MuiCheckbox-root"
             tabindex="-1"
           >
             <input
               aria-labelledby="checkbox-list-label-test_1"
               class="PrivateSwitchBase-input css-1m9pwf3"
-              data-indeterminate="false"
+              data-indeterminate="true"
               disabled=""
               type="checkbox"
             />
             <svg
               aria-hidden="true"
               class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-ptiqhd-MuiSvgIcon-root"
-              data-testid="CheckBoxOutlineBlankIcon"
+              data-testid="IndeterminateCheckBoxIcon"
               focusable="false"
               viewBox="0 0 24 24"
             >
               <path
-                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10H7v-2h10v2z"
               />
             </svg>
           </span>

--- a/src/channels/channelTree.component.test.tsx
+++ b/src/channels/channelTree.component.test.tsx
@@ -27,7 +27,7 @@ describe('Channel Tree', () => {
     children: {
       test_1: {
         name: 'test_1',
-        checked: false,
+        checked: undefined,
         children: {
           timestamp: { ...staticChannels['timestamp'], checked: false },
           [channel1.systemName]: {

--- a/src/channels/channelTree.component.tsx
+++ b/src/channels/channelTree.component.tsx
@@ -58,11 +58,14 @@ const ChannelTree = (props: ChannelTreeProps) => {
             >
               <ListItemIcon>
                 <Checkbox
-                  checked={value?.checked}
+                  checked={value.checked}
+                  indeterminate={typeof value.checked === 'undefined'}
                   disabled={!leaf || key === timeChannelName}
                   size="small"
                   inputProps={{ 'aria-labelledby': labelId }}
-                  onClick={() => handleChannelChecked(key, value.checked)}
+                  onClick={() =>
+                    leaf && handleChannelChecked(key, value.checked)
+                  }
                 />
               </ListItemIcon>
               <ListItemText id={labelId} primary={value?.name ?? key} />

--- a/src/channels/channelsDialogue.component.test.tsx
+++ b/src/channels/channelsDialogue.component.test.tsx
@@ -17,16 +17,15 @@ import { staticChannels } from '../api/channels';
 
 describe('selectChannelTree', () => {
   it('transforms channel list with selection info into TreeNode', () => {
-    const selectedIds = ['timestamp', 'shotnum', 'CHANNEL_ABCDE'];
+    const selectedIds = [...Object.keys(staticChannels), 'CHANNEL_ABCDE'];
     const channelTree = selectChannelTree({}, testChannels, selectedIds);
 
     const expectedTree: TreeNode = {
       name: '/',
-      checked: false,
       children: {
         system: {
           name: 'system',
-          checked: false,
+          checked: true,
           children: Object.fromEntries(
             Object.entries(staticChannels).map(([channelName, channel]) => [
               channelName,
@@ -39,11 +38,11 @@ describe('selectChannelTree', () => {
         },
         Channels: {
           name: 'Channels',
-          checked: false,
+          checked: undefined,
           children: {
             '1': {
               name: '1',
-              checked: false,
+              checked: undefined,
               children: testChannels.reduce((prev, curr) => {
                 if (curr.path.includes('1'))
                   prev[curr.systemName] = {


### PR DESCRIPTION
## Description
Update the channel tree so that non-leaf nodes have their checkboxes set to true, false or indeterminate based on whether all, none or some of their children are selected respectively.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
Closes DSEGOG-140
