### PR TITLE
Add an auto refresh toggle when relative timeframe is set

### DIFF
--- a/src/search/components/__snapshots__/maxShots.component.test.tsx.snap
+++ b/src/search/components/__snapshots__/maxShots.component.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`maxShots search renders correctly with a selected value 1`] = `
   >
     <div
       aria-label="select max shots to display"
-      class="MuiBox-root css-1hqcbhu"
+      class="MuiBox-root css-2sv9t8"
     >
       <div
         style="align-items: center; display: flex; justify-content: left; margin-right: 10px;"

--- a/src/search/components/autoRefreshToggle.component.test.tsx
+++ b/src/search/components/autoRefreshToggle.component.test.tsx
@@ -14,10 +14,10 @@ describe('AutoRefreshToggle', () => {
     jest.useRealTimers();
   });
 
-  it('should enable auto refresh by default', () => {
+  it('should enable auto refresh if enabled', () => {
     const onRequestRefresh = jest.fn();
 
-    render(<AutoRefreshToggle onRequestRefresh={onRequestRefresh} />);
+    render(<AutoRefreshToggle enabled onRequestRefresh={onRequestRefresh} />);
 
     expect(
       screen.getByRole('checkbox', { name: 'Auto refresh' })
@@ -28,13 +28,29 @@ describe('AutoRefreshToggle', () => {
     expect(onRequestRefresh).toBeCalled();
   });
 
-  it('should cancel auto refresh when disabled', async () => {
+  it('should not enable auto refresh if disabled', () => {
+    const onRequestRefresh = jest.fn();
+
+    render(
+      <AutoRefreshToggle enabled={false} onRequestRefresh={onRequestRefresh} />
+    );
+
+    expect(
+      screen.getByRole('checkbox', { name: 'Auto refresh' })
+    ).not.toBeChecked();
+
+    jest.advanceTimersByTime(AUTO_REFRESH_INTERVAL_MS);
+
+    expect(onRequestRefresh).not.toBeCalled();
+  });
+
+  it('should cancel auto refresh when unchecked', async () => {
     const user = userEvent.setup({
       advanceTimers: jest.advanceTimersByTime,
     });
     const onRequestRefresh = jest.fn();
 
-    render(<AutoRefreshToggle onRequestRefresh={onRequestRefresh} />);
+    render(<AutoRefreshToggle enabled onRequestRefresh={onRequestRefresh} />);
 
     // run the timer to run the callback once
     jest.advanceTimersByTime(AUTO_REFRESH_INTERVAL_MS);

--- a/src/search/components/autoRefreshToggle.component.test.tsx
+++ b/src/search/components/autoRefreshToggle.component.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import AutoRefreshToggle, {
+  AUTO_REFRESH_INTERVAL_MS,
+} from './autoRefreshToggle.component';
+import userEvent from '@testing-library/user-event';
+// import userEvent from '@testing-library/user-event';
+
+describe('AutoRefreshToggle', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should enable auto refresh by default', () => {
+    const onRequestRefresh = jest.fn();
+
+    render(<AutoRefreshToggle onRequestRefresh={onRequestRefresh} />);
+
+    expect(
+      screen.getByRole('checkbox', { name: 'Auto refresh' })
+    ).toBeChecked();
+
+    jest.advanceTimersByTime(AUTO_REFRESH_INTERVAL_MS);
+
+    expect(onRequestRefresh).toBeCalled();
+  });
+
+  it('should cancel auto refresh when disabled', async () => {
+    const user = userEvent.setup({
+      advanceTimers: jest.advanceTimersByTime,
+    });
+    const onRequestRefresh = jest.fn();
+
+    render(<AutoRefreshToggle onRequestRefresh={onRequestRefresh} />);
+
+    // run the timer to run the callback once
+    jest.advanceTimersByTime(AUTO_REFRESH_INTERVAL_MS);
+
+    expect(onRequestRefresh).toBeCalledTimes(1);
+
+    const toggle = screen.getByRole('checkbox', { name: 'Auto refresh' });
+
+    await user.click(toggle);
+    expect(toggle).not.toBeChecked();
+
+    // wait for another interval to make sure the callback is not called again
+    jest.advanceTimersByTime(AUTO_REFRESH_INTERVAL_MS);
+
+    expect(onRequestRefresh).toBeCalledTimes(1);
+  });
+});

--- a/src/search/components/autoRefreshToggle.component.tsx
+++ b/src/search/components/autoRefreshToggle.component.tsx
@@ -1,0 +1,57 @@
+import { FormControlLabel, Switch } from '@mui/material';
+import React from 'react';
+
+interface AutoRefreshToggleProps {
+  onRequestRefresh: () => void;
+}
+
+const DEFAULT_AUTO_REFRESH_ENABLED = true;
+const AUTO_REFRESH_INTERVAL_MS = 1000 * 60;
+
+function AutoRefreshToggle({
+  onRequestRefresh,
+}: AutoRefreshToggleProps): JSX.Element {
+  const [isAutoRefreshEnabled, setIsAutoRefreshEnabled] = React.useState(
+    DEFAULT_AUTO_REFRESH_ENABLED
+  );
+  const autoRefreshTimeout = React.useRef<ReturnType<
+    typeof setInterval
+  > | null>(null);
+
+  React.useEffect(() => {
+    if (autoRefreshTimeout.current) {
+      clearInterval(autoRefreshTimeout.current);
+    }
+
+    if (isAutoRefreshEnabled) {
+      autoRefreshTimeout.current = setInterval(() => {
+        onRequestRefresh();
+      }, AUTO_REFRESH_INTERVAL_MS);
+    }
+
+    return () => {
+      if (autoRefreshTimeout.current) {
+        clearInterval(autoRefreshTimeout.current);
+      }
+    };
+  }, [isAutoRefreshEnabled, onRequestRefresh]);
+
+  function toggleAutoRefresh(enabled: boolean) {
+    setIsAutoRefreshEnabled(enabled);
+  }
+
+  return (
+    <FormControlLabel
+      control={
+        <Switch
+          checked={isAutoRefreshEnabled}
+          onChange={(_, checked) => toggleAutoRefresh(checked)}
+        />
+      }
+      label="Auto refresh"
+    />
+  );
+}
+
+export default AutoRefreshToggle;
+export { AUTO_REFRESH_INTERVAL_MS };

--- a/src/search/components/autoRefreshToggle.component.tsx
+++ b/src/search/components/autoRefreshToggle.component.tsx
@@ -2,6 +2,7 @@ import { FormControlLabel, Switch } from '@mui/material';
 import React from 'react';
 
 interface AutoRefreshToggleProps {
+  enabled: boolean;
   onRequestRefresh: () => void;
 }
 
@@ -9,6 +10,7 @@ const DEFAULT_AUTO_REFRESH_ENABLED = true;
 const AUTO_REFRESH_INTERVAL_MS = 1000 * 60;
 
 function AutoRefreshToggle({
+  enabled,
   onRequestRefresh,
 }: AutoRefreshToggleProps): JSX.Element {
   const [isAutoRefreshEnabled, setIsAutoRefreshEnabled] = React.useState(
@@ -19,6 +21,8 @@ function AutoRefreshToggle({
   > | null>(null);
 
   React.useEffect(() => {
+    if (!enabled) return;
+
     if (autoRefreshTimeout.current) {
       clearInterval(autoRefreshTimeout.current);
     }
@@ -34,7 +38,7 @@ function AutoRefreshToggle({
         clearInterval(autoRefreshTimeout.current);
       }
     };
-  }, [isAutoRefreshEnabled, onRequestRefresh]);
+  }, [enabled, isAutoRefreshEnabled, onRequestRefresh]);
 
   function toggleAutoRefresh(enabled: boolean) {
     setIsAutoRefreshEnabled(enabled);
@@ -44,7 +48,8 @@ function AutoRefreshToggle({
     <FormControlLabel
       control={
         <Switch
-          checked={isAutoRefreshEnabled}
+          disabled={!enabled}
+          checked={isAutoRefreshEnabled && enabled}
           onChange={(_, checked) => toggleAutoRefresh(checked)}
         />
       }

--- a/src/search/components/maxShots.component.tsx
+++ b/src/search/components/maxShots.component.tsx
@@ -26,7 +26,6 @@ const MaxShots = (props: MaxShotsProps): React.ReactElement => {
         sx={{
           display: 'flex',
           flexDirection: 'row',
-          paddingRight: 5,
           overflow: 'hidden',
         }}
       >

--- a/src/search/searchBar.component.test.tsx
+++ b/src/search/searchBar.component.test.tsx
@@ -290,7 +290,7 @@ describe('searchBar component', () => {
         },
       ],
       () => {
-        return { data: [recordsJson[0], recotrdsJson[1]] };
+        return { data: [recordsJson[0], recordsJson[1]] };
       }
     );
 

--- a/src/search/searchBar.component.test.tsx
+++ b/src/search/searchBar.component.test.tsx
@@ -18,7 +18,7 @@ import { server } from '../mocks/server';
 import recordsJson from '../mocks/records.json';
 
 describe('searchBar component', () => {
-  let user;
+  let user: ReturnType<typeof userEvent.setup>;
   let props: React.ComponentProps<typeof SearchBar>;
 
   const createView = (
@@ -290,7 +290,7 @@ describe('searchBar component', () => {
         },
       ],
       () => {
-        return { data: [recordsJson[0], recordsJson[1]] };
+        return { data: [recordsJson[0], recotrdsJson[1]] };
       }
     );
 
@@ -362,6 +362,10 @@ describe('searchBar component', () => {
       await user.click(screen.getByLabelText('close timeframe search box'));
       await user.click(screen.getByRole('button', { name: 'Search' }));
 
+      expect(
+        await screen.findByRole('checkbox', { name: 'Auto refresh' })
+      ).toBeInTheDocument();
+
       const actualFromDate =
         store.getState().search.searchParams.dateRange.fromDate;
       const actualToDate =
@@ -387,6 +391,10 @@ describe('searchBar component', () => {
       await user.click(screen.getByLabelText('close timeframe search box'));
       await user.click(screen.getByRole('button', { name: 'Search' }));
 
+      expect(
+        await screen.findByRole('checkbox', { name: 'Auto refresh' })
+      ).toBeInTheDocument();
+
       const actualFromDate =
         store.getState().search.searchParams.dateRange.fromDate;
       const actualToDate =
@@ -411,6 +419,10 @@ describe('searchBar component', () => {
       const expectedFromDate = new Date('2022-01-04 12:00:00');
       await user.click(screen.getByLabelText('close timeframe search box'));
       await user.click(screen.getByRole('button', { name: 'Search' }));
+
+      expect(
+        await screen.findByRole('checkbox', { name: 'Auto refresh' })
+      ).toBeInTheDocument();
 
       const actualFromDate =
         store.getState().search.searchParams.dateRange.fromDate;

--- a/src/search/searchBar.component.tsx
+++ b/src/search/searchBar.component.tsx
@@ -6,6 +6,7 @@ import Timeframe, {
 import Experiment from './components/experiment.component';
 import ShotNumber from './components/shotNumber.component';
 import MaxShots from './components/maxShots.component';
+import AutoRefreshToggle from './components/autoRefreshToggle.component';
 import {
   Grid,
   Button,
@@ -362,7 +363,7 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
               </Grid>
             </Grid>
           </Grid>
-          <Grid container direction="row">
+          <Grid container direction="row" columnGap={5}>
             <Grid item>
               <MaxShots maxShots={maxShots} changeMaxShots={setMaxShots} />
             </Grid>
@@ -372,6 +373,11 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
                 refreshData={refreshData}
               />
             </Grid>
+            {timeframeRange && !paramsUpdated && (
+              <Grid item>
+                <AutoRefreshToggle onRequestRefresh={refreshData} />
+              </Grid>
+            )}
           </Grid>
         </Grid>
       </Grid>

--- a/src/search/searchBar.component.tsx
+++ b/src/search/searchBar.component.tsx
@@ -373,11 +373,12 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
                 refreshData={refreshData}
               />
             </Grid>
-            {timeframeRange && !paramsUpdated && (
-              <Grid item>
-                <AutoRefreshToggle onRequestRefresh={refreshData} />
-              </Grid>
-            )}
+            <Grid item>
+              <AutoRefreshToggle
+                enabled={Boolean(timeframeRange)}
+                onRequestRefresh={refreshData}
+              />
+            </Grid>
           </Grid>
         </Grid>
       </Grid>


### PR DESCRIPTION
## Description
This PR adds a toggle next to the refresh button that allows users to enable auto refresh of data when a relative time frame is set, e.g. "last 10 minutes".

I set the auto refresh to happen every minute, but happy to change it if needed.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
connect to DSEGOG-86
