### PR TITLE
Debounce the shotnum and date range inputs in the search bar component DSEGOG-431

### DIFF
--- a/cypress/e2e/search.cy.ts
+++ b/cypress/e2e/search.cy.ts
@@ -589,6 +589,8 @@ describe('Search', () => {
       cy.findByRole('spinbutton', { name: 'Min' }).type('1');
       cy.findByRole('spinbutton', { name: 'Max' }).type('9');
 
+      cy.findByDisplayValue('2022-01-01 00:00').should('exist');
+      cy.findByDisplayValue('2022-01-09 00:00').should('exist');
       cy.startSnoopingBrowserMockedRequest();
 
       cy.findByRole('button', { name: 'Search' }).click();
@@ -1025,6 +1027,7 @@ describe('Search', () => {
         .contains('ID 22110007')
         .should('exist');
 
+      cy.findByText('13 to 15').should('exist');
       cy.findByLabelText('open shot number search box').click();
       cy.findByRole('dialog')
         .findByRole('spinbutton', {
@@ -1036,22 +1039,43 @@ describe('Search', () => {
           name: 'Min',
         })
         .type('12');
+
+      cy.findByText('12 to 15').should('exist');
       cy.findByLabelText('close shot number search box').click();
 
       cy.findByLabelText('open experiment search box')
         .contains('ID 22110007')
         .should('not.exist');
 
+      cy.findByLabelText('open shot number search box').click();
+      cy.findByRole('dialog')
+        .findByRole('spinbutton', {
+          name: 'Min',
+        })
+        .clear();
+
+      cy.findByRole('dialog')
+        .findByRole('spinbutton', {
+          name: 'Max',
+        })
+        .clear();
+
+      cy.findByText('12 to 15').should('not.exist');
+      cy.findByLabelText('close shot number search box').click();
+
       cy.findByLabelText('open experiment search box').click();
       cy.findByRole('combobox', { name: 'Select your experiment' }).type('221');
       cy.findByRole('combobox', { name: 'Select your experiment' }).type(
         '{downArrow}{enter}'
       );
+
       cy.findByLabelText('close experiment search box').click();
-      cy.findByLabelText('open experiment search box')
+
+      cy.findByLabelText('open experiment search box', { timeout: 10000 })
         .contains('ID 22110007')
         .should('exist');
 
+      cy.findByText('13 to 15').should('exist');
       cy.findByLabelText('open shot number search box').click();
       cy.findByRole('dialog')
         .findByRole('spinbutton', {
@@ -1063,6 +1087,8 @@ describe('Search', () => {
           name: 'Max',
         })
         .type('16');
+
+      cy.findByText('13 to 16').should('exist');
       cy.findByLabelText('close shot number search box').click();
 
       cy.findByLabelText('open experiment search box')

--- a/src/search/searchBar.component.test.tsx
+++ b/src/search/searchBar.component.test.tsx
@@ -78,6 +78,9 @@ describe('searchBar component', () => {
       within(maxShotsRadioGroup).getByLabelText('Select 1000 max shots')
     );
 
+    await waitFor(() => {
+      expect(screen.getByText('1 to 2')).toBeInTheDocument();
+    });
     // Initiate search
 
     await user.click(screen.getByRole('button', { name: 'Search' }));
@@ -106,6 +109,10 @@ describe('searchBar component', () => {
 
     await user.type(experimentPopup, '221{arrowdown}{enter}');
     expect(experimentPopup).toHaveValue('22110007');
+
+    await waitFor(() => {
+      expect(screen.getByText('13 to 15')).toBeInTheDocument();
+    });
     // Shot number fields
 
     await user.click(screen.getByLabelText('open shot number search box'));
@@ -117,8 +124,9 @@ describe('searchBar component', () => {
       name: 'Max',
     });
     await user.clear(shotnumMin);
-    await user.clear(shotnumMax);
     await user.type(shotnumMin, '5');
+
+    await user.clear(shotnumMax);
     await user.type(shotnumMax, '10');
     await user.click(screen.getByLabelText('close shot number search box'));
 
@@ -130,6 +138,12 @@ describe('searchBar component', () => {
     await user.click(
       within(maxShotsRadioGroup).getByLabelText('Select 1000 max shots')
     );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('ID 22110007 (part 1)')
+      ).not.toBeInTheDocument();
+    });
 
     // Initiate search
 
@@ -158,6 +172,10 @@ describe('searchBar component', () => {
     await user.type(experimentPopup, '221{arrowdown}{enter}');
     expect(experimentPopup).toHaveValue('22110007');
 
+    await waitFor(() => {
+      expect(screen.getByText('13 to 15')).toBeInTheDocument();
+    });
+
     // Shot number fields
 
     await user.click(screen.getByLabelText('open shot number search box'));
@@ -180,6 +198,12 @@ describe('searchBar component', () => {
     await user.click(
       within(maxShotsRadioGroup).getByLabelText('Select 1000 max shots')
     );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('ID 22110007 (part 1)')
+      ).not.toBeInTheDocument();
+    });
 
     // Initiate search
 
@@ -208,6 +232,10 @@ describe('searchBar component', () => {
     await user.type(experimentPopup, '221{arrowdown}{enter}');
     expect(experimentPopup).toHaveValue('22110007');
 
+    await waitFor(() => {
+      expect(screen.getByText('13 to 15')).toBeInTheDocument();
+    });
+
     // Shot number fields
 
     await user.click(screen.getByLabelText('open shot number search box'));
@@ -231,6 +259,11 @@ describe('searchBar component', () => {
       within(maxShotsRadioGroup).getByLabelText('Select 1000 max shots')
     );
 
+    await waitFor(() => {
+      expect(
+        screen.queryByText('ID 22110007 (part 1)')
+      ).not.toBeInTheDocument();
+    });
     // Initiate search
 
     await user.click(screen.getByRole('button', { name: 'Search' }));
@@ -267,6 +300,10 @@ describe('searchBar component', () => {
 
     await user.type(experimentPopup, '221{arrowdown}{enter}');
 
+    await waitFor(() => {
+      expect(screen.getByText('13 to 15')).toBeInTheDocument();
+    });
+
     await user.click(screen.getByRole('button', { name: 'Search' }));
     expect(store.getState().search.searchParams).toStrictEqual({
       dateRange: {
@@ -292,6 +329,10 @@ describe('searchBar component', () => {
     const dateFilterToDate = screen.getByLabelText('to, date-time input');
     await user.type(dateFilterFromDate, '2022-01-01_00:00');
     await user.type(dateFilterToDate, '2022-01-02_00:00');
+
+    await waitFor(() => {
+      expect(screen.getByText('1 to 2')).toBeInTheDocument();
+    });
 
     // Initiate search
 
@@ -398,7 +439,7 @@ describe('searchBar component', () => {
     await user.type(shotnumMax, '2');
     await user.type(shotnumMin, '10');
 
-    let helperTexts = screen.getAllByText('Invalid range');
+    let helperTexts = await screen.findAllByText('Invalid range');
 
     // One helper text below each input
     expect(helperTexts.length).toEqual(2);
@@ -479,6 +520,10 @@ describe('searchBar component', () => {
       experimentID: null,
       shotnumRange: {},
       maxShots: MAX_SHOTS_VALUES[0],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('1 to 18')).toBeInTheDocument();
     });
 
     // Try search again
@@ -636,6 +681,10 @@ describe('searchBar component', () => {
 
     const dateFilterToDate = screen.getByLabelText('to, date-time input');
     await user.type(dateFilterToDate, '2023-01-01_00:00');
+
+    await waitFor(() => {
+      expect(screen.getByText('1 to 18')).toBeInTheDocument();
+    });
 
     await user.click(screen.getByRole('button', { name: 'Search' }));
 

--- a/src/search/searchBar.component.tsx
+++ b/src/search/searchBar.component.tsx
@@ -40,6 +40,7 @@ import Timeframe, {
   type TimeframeRange,
 } from './components/timeframe.component';
 
+export const DEBOUNCE_TIME = 500;
 export type TimeframeDates = {
   fromDate: Date | null;
   toDate: Date | null;
@@ -202,47 +203,74 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
   // need this to help keep track of invalid date ranges in the datetime component itself
   const [datePickerError, setDatePickerError] = React.useState(false);
 
+  // Debounce date range for the converter
+  const [debouncedFromDate, setDebouncedFromDate] = React.useState<Date | null>(
+    searchParameterFromDate
+  );
+  const [debouncedToDate, setDebouncedToDate] = React.useState<Date | null>(
+    searchParameterToDate
+  );
+
   const invalidDateRange =
-    (searchParameterFromDate !== null &&
-      searchParameterToDate !== null &&
-      searchParameterFromDate &&
-      searchParameterToDate &&
-      isBefore(searchParameterToDate, searchParameterFromDate)) ||
-    (!searchParameterFromDate && searchParameterToDate !== null) ||
-    (searchParameterFromDate !== null && !searchParameterToDate) ||
+    (debouncedFromDate !== null &&
+      debouncedToDate !== null &&
+      debouncedFromDate &&
+      debouncedToDate &&
+      isBefore(debouncedToDate, debouncedFromDate)) ||
+    (!debouncedFromDate && debouncedToDate !== null) ||
+    (debouncedFromDate !== null && !debouncedToDate) ||
     datePickerError;
 
-  const invalidShotNumberRange =
-    (searchParameterShotnumMin !== undefined &&
-      searchParameterShotnumMax !== undefined &&
-      searchParameterShotnumMin > searchParameterShotnumMax) ||
-    (searchParameterShotnumMin === undefined &&
-      searchParameterShotnumMax !== undefined) ||
-    (searchParameterShotnumMin !== undefined &&
-      searchParameterShotnumMax === undefined);
+  React.useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedFromDate(searchParameterFromDate);
+      setDebouncedToDate(searchParameterToDate);
+    }, DEBOUNCE_TIME); // 300ms debounce
+
+    return () => clearTimeout(handler);
+  }, [searchParameterFromDate, searchParameterToDate]);
 
   // Date range to shot number range converter
   const { data: dateToShotnum } = useDateToShotnumConverter(
-    searchParameterFromDate
-      ? formatDateTimeForApi(searchParameterFromDate)
-      : undefined,
-    searchParameterToDate
-      ? formatDateTimeForApi(searchParameterToDate)
-      : undefined,
+    debouncedFromDate ? formatDateTimeForApi(debouncedFromDate) : undefined,
+    debouncedToDate ? formatDateTimeForApi(debouncedToDate) : undefined,
     // only enable query when dates are not null and the range is valid
     !invalidDateRange &&
-      !(searchParameterFromDate === null && searchParameterToDate === null)
+      !(debouncedFromDate === null && debouncedToDate === null)
   );
+  // Debounce shot number min and max for the converter
+  const [debouncedShotnumMin, setDebouncedShotnumMin] = React.useState<
+    number | undefined
+  >(searchParameterShotnumMin);
+  const [debouncedShotnumMax, setDebouncedShotnumMax] = React.useState<
+    number | undefined
+  >(searchParameterShotnumMax);
+
+  const invalidShotNumberRange =
+    (debouncedShotnumMin !== undefined &&
+      debouncedShotnumMax !== undefined &&
+      debouncedShotnumMin > debouncedShotnumMax) ||
+    (debouncedShotnumMin === undefined && debouncedShotnumMax !== undefined) ||
+    (debouncedShotnumMin !== undefined && debouncedShotnumMax === undefined);
+
+  React.useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedShotnumMin(searchParameterShotnumMin);
+      setDebouncedShotnumMax(searchParameterShotnumMax);
+    }, DEBOUNCE_TIME); // 300ms debounce
+
+    return () => clearTimeout(handler);
+  }, [searchParameterShotnumMin, searchParameterShotnumMax]);
 
   // Shot number range to date range converter
   const { data: shotnumToDate } = useShotnumToDateConverter(
-    searchParameterShotnumMin,
-    searchParameterShotnumMax,
+    debouncedShotnumMin,
+    debouncedShotnumMax,
     // only enable query when shot numbers are not undefined and the range is valid
     !invalidShotNumberRange &&
       !(
-        typeof searchParameterShotnumMin === 'undefined' &&
-        typeof searchParameterShotnumMax === 'undefined'
+        typeof debouncedShotnumMin === 'undefined' &&
+        typeof debouncedShotnumMax === 'undefined'
       )
   );
 


### PR DESCRIPTION
## Description
- As the shotnum and date ranges are linked by the shotnumToDateRangeConverter and dateRangeToShotnumConverter functions, we need to debounce both inputs to prevent unnecessary API calls while the user is typing

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
closes DSEGOG-431
