### PR TITLE
DSEGOG-442 Always assume API uses UTC timestamps 

### DIFF
--- a/e2e/mocked/vectors.spec.ts
+++ b/e2e/mocked/vectors.spec.ts
@@ -345,6 +345,8 @@ test('should display an error if vector upper bound or skip is not a valid numbe
 
   const vectorLimitInput = await page.getByLabel('Upper Bound');
 
+  await vectorLimitInput.scrollIntoViewIfNeeded();
+
   await vectorLimitInput.fill('abc');
 
   await expect(
@@ -373,6 +375,8 @@ test('should display an error if vector upper bound is less than vector lower bo
   const vectorLimitInput = await page.getByLabel('Upper Bound');
   const vectorSkipInput = await page.getByLabel('Lower Bound');
 
+  await vectorLimitInput.scrollIntoViewIfNeeded();
+
   await vectorSkipInput.fill('20');
 
   await vectorLimitInput.fill('10');
@@ -396,6 +400,8 @@ test('should display an error if vector upper bound is negative', async ({
     document.body.appendChild(div);
   });
   const vectorLimitInput = await page.getByLabel('Upper Bound');
+
+  await vectorLimitInput.scrollIntoViewIfNeeded();
 
   await vectorLimitInput.fill('-1');
 

--- a/e2e/real/functions.spec.ts
+++ b/e2e/real/functions.spec.ts
@@ -161,7 +161,7 @@ test('create a function that depends on another function and display it without 
   // Click on the apply button
   await page.getByRole('button', { name: 'Apply' }).click();
 
-  await expect(page.getByText('12.035422071878786')).toBeVisible({
+  await expect(page.getByText('16.64933209010296')).toBeVisible({
     timeout: 200000,
   });
 });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "@date-io/date-fns": "3.2.0",
+    "@date-fns/tz": "1.4.1",
+    "@date-io/date-fns": "3.2.1",
     "@emotion/cache": "11.14.0",
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.0",
@@ -26,7 +27,7 @@
     "axios": "1.11.0",
     "browserslist": "4.24.2",
     "browserslist-to-esbuild": "2.1.1",
-    "date-fns": "3.6.0",
+    "date-fns": "4.1.0",
     "hacktimer": "1.1.3",
     "husky": "9.1.1",
     "loglevel": "1.9.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -68,6 +68,7 @@ const config: PlaywrightTestConfig = {
               channel: 'chromium',
               // Use prepared auth state.
               storageState: 'e2e/real/.auth/user.json',
+              timezoneId: 'UTC',
             },
             testDir: './e2e/real',
             testIgnore: /.*sessions.spec.ts/,
@@ -88,6 +89,7 @@ const config: PlaywrightTestConfig = {
               },
               // Use prepared auth state.
               storageState: 'e2e/real/.auth/user.json',
+              timezoneId: 'UTC',
             },
             testDir: './e2e/real',
             testMatch: /.*sessions.spec.ts/,
@@ -100,6 +102,7 @@ const config: PlaywrightTestConfig = {
             use: {
               ...devices['Desktop Chrome'],
               channel: 'chromium',
+              timezoneId: 'UTC',
             },
             testDir: './e2e/mocked',
           },
@@ -116,6 +119,7 @@ const config: PlaywrightTestConfig = {
                   'ui.allPointerCapabilities': 0x02 | 0x04,
                 },
               },
+              timezoneId: 'UTC',
             },
             testDir: './e2e/mocked',
           },
@@ -125,37 +129,10 @@ const config: PlaywrightTestConfig = {
             use: {
               ...devices['Desktop Safari'],
               deviceScaleFactor: 1,
+              timezoneId: 'UTC',
             },
             testDir: './e2e/mocked',
           },
-
-          /* Test against mobile viewports. */
-          // {
-          //   name: 'Mobile Chrome',
-          //   use: {
-          //     ...devices['Pixel 5'],
-          //   },
-          // },
-          // {
-          //   name: 'Mobile Safari',
-          //   use: {
-          //     ...devices['iPhone 12'],
-          //   },
-          // },
-
-          /* Test against branded browsers. */
-          // {
-          //   name: 'Microsoft Edge',
-          //   use: {
-          //     channel: 'msedge',
-          //   },
-          // },
-          // {
-          //   name: 'Google Chrome',
-          //   use: {
-          //     channel: 'chrome',
-          //   },
-          // },
         ],
 
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */

--- a/src/api/api.test.tsx
+++ b/src/api/api.test.tsx
@@ -1,0 +1,26 @@
+import { convertApiTimestampToDate, formatDateTimeForApi } from './api';
+
+describe('API timestamp conversion functions', () => {
+  beforeEach(() => {
+    vi.stubEnv('TZ', 'Etc/GMT-1'); // POSIX timezone so this is "opposite" so this is UTC+1 aka BST
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('formatDateTimeForApi', () => {
+    it('returns a correctly formatted string', () => {
+      const testDate = new Date('2022-01-01 01:00:00');
+      const result = formatDateTimeForApi(testDate);
+      expect(result).toEqual('2022-01-01T00:00:00');
+    });
+  });
+
+  describe('convertApiTimestampToDate', () => {
+    it('returns a local date', () => {
+      const result = convertApiTimestampToDate('2022-01-01T00:00:00');
+      expect(result).toEqual(new Date('2022-01-01 01:00:00'));
+    });
+  });
+});

--- a/src/api/api.tsx
+++ b/src/api/api.tsx
@@ -1,4 +1,6 @@
+import { tz } from '@date-fns/tz';
 import axios from 'axios';
+import { format, parseISO } from 'date-fns';
 import { MicroFrontendId, type APIError } from '../app.types';
 import { readSciGatewayToken } from '../parseTokens';
 import { settings } from '../settings';
@@ -86,3 +88,10 @@ ogApi.interceptors.response.use(
     else return Promise.reject(error);
   }
 );
+
+export const formatDateTimeForApi = (datetime: Date): string => {
+  return format(datetime, "yyyy-MM-dd'T'HH:mm:ss", { in: tz('UTC') });
+};
+
+export const convertApiTimestampToDate = (apiTimestamp: string): Date =>
+  parseISO(`${apiTimestamp}Z`);

--- a/src/api/records.tsx
+++ b/src/api/records.tsx
@@ -400,6 +400,9 @@ export const useRecordsPaginated = (): UseQueryResult<
   });
 };
 
+export const convertApiTimestampToDate = (apiTimestamp: string): Date =>
+  parseISO(`${apiTimestamp}Z`);
+
 export const getFormattedAxisData = (
   record: Record,
   axisName: string
@@ -408,7 +411,9 @@ export const getFormattedAxisData = (
 
   switch (axisName) {
     case 'timestamp':
-      formattedData = parseISO(record.metadata.timestamp).getTime();
+      formattedData = convertApiTimestampToDate(
+        record.metadata.timestamp
+      ).getTime();
       break;
     case 'shotnum':
       formattedData = record.metadata.shotnum ?? NaN;

--- a/src/api/records.tsx
+++ b/src/api/records.tsx
@@ -4,7 +4,6 @@ import {
   UseQueryResult,
 } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import { parseISO } from 'date-fns';
 import {
   APIFunctionState,
   DateRangetoShotnumConverter,
@@ -25,7 +24,7 @@ import { useAppSelector } from '../state/hooks';
 import { selectQueryParams } from '../state/slices/searchSlice';
 import { selectSelectedIdsIgnoreOrder } from '../state/slices/tableSlice';
 import { renderTimestamp } from '../table/cellRenderers/cellContentRenderers';
-import { ogApi } from './api';
+import { convertApiTimestampToDate, ogApi } from './api';
 import { staticChannels } from './channels';
 
 const fetchRecords = async (
@@ -399,9 +398,6 @@ export const useRecordsPaginated = (): UseQueryResult<
       }),
   });
 };
-
-export const convertApiTimestampToDate = (apiTimestamp: string): Date =>
-  parseISO(`${apiTimestamp}Z`);
 
 export const getFormattedAxisData = (
   record: Record,

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,9 +1,8 @@
-import { bypass, delay, http, HttpResponse } from 'msw';
+import { delay, http, HttpResponse } from 'msw';
 import { ColourMapsParams } from '../api/images';
 import {
   APIErrorResponse,
   Channel,
-  ExperimentParams,
   isChannelScalar,
   PREFERRED_COLOUR_MAP_PREFERENCE_NAME,
   PREFERRED_NULLABLE_COLOUR_MAP_PREFERENCE_NAME,
@@ -155,51 +154,6 @@ export const handlers = [
   }),
   http.get('/experiments', () => {
     return HttpResponse.json(experimentsJson, { status: 200 });
-  }),
-  http.get('*/experiments', async ({ request }) => {
-    const originalResponse = await fetch(bypass(request));
-    // Retrieve the original response data
-    const originalData = await originalResponse.json();
-    const adjustDates = (
-      dictList: ExperimentParams[],
-      rangeStart: Date,
-      rangeEnd: Date
-    ): ExperimentParams[] => {
-      const sortedList = [...dictList].sort(
-        (a, b) =>
-          new Date(a.start_date).getTime() - new Date(b.start_date).getTime()
-      );
-
-      const experimentRange =
-        (rangeEnd.getTime() - rangeStart.getTime()) / dictList.length;
-
-      let currentStartDate = rangeStart;
-
-      for (const experiment of sortedList) {
-        const startDate = currentStartDate.toISOString();
-        const endDate = new Date(
-          currentStartDate.getTime() + experimentRange
-        ).toISOString();
-
-        experiment.start_date = startDate;
-        experiment.end_date = endDate;
-
-        currentStartDate = new Date(
-          currentStartDate.getTime() + experimentRange
-        );
-      }
-
-      return sortedList;
-    };
-    // The start and end dates are derived from the
-    // operations gateway api data
-    const startDate = new Date('2022-04-07 14:16:16');
-    const endDate = new Date('2022-04-08 09:44:01');
-
-    return HttpResponse.json(
-      adjustDates(originalData as ExperimentParams[], startDate, endDate),
-      { status: 200 }
-    );
   }),
   http.get('/records', () => HttpResponse.json(recordsJson, { status: 200 })),
   http.get('/records/count', () =>

--- a/src/plotting/plotSettings/xAxisTab.component.test.tsx
+++ b/src/plotting/plotSettings/xAxisTab.component.test.tsx
@@ -2,8 +2,8 @@ import type { QueryClient } from '@tanstack/react-query';
 import { fireEvent, screen, within } from '@testing-library/react';
 import userEvent, { UserEvent } from '@testing-library/user-event';
 import { format } from 'date-fns';
+import { convertApiTimestampToDate } from '../../api/api';
 import { staticChannels } from '../../api/channels';
-import { convertApiTimestampToDate } from '../../api/records';
 import type { FullScalarChannelMetadata } from '../../app.types';
 import type { RootState } from '../../state/store';
 import {

--- a/src/plotting/plotSettings/xAxisTab.component.test.tsx
+++ b/src/plotting/plotSettings/xAxisTab.component.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, screen, within } from '@testing-library/react';
 import userEvent, { UserEvent } from '@testing-library/user-event';
 import { format } from 'date-fns';
 import { staticChannels } from '../../api/channels';
+import { convertApiTimestampToDate } from '../../api/records';
 import type { FullScalarChannelMetadata } from '../../app.types';
 import type { RootState } from '../../state/store';
 import {
@@ -252,7 +253,9 @@ describe('x-axis tab', () => {
         await userEvent.click(shortcutButton);
 
         const date = state.search?.searchParams.dateRange.fromDate
-          ? new Date(state.search.searchParams.dateRange.fromDate)
+          ? convertApiTimestampToDate(
+              state.search.searchParams.dateRange.fromDate
+            )
           : null;
 
         expect(changeXMinimum).toHaveBeenCalledWith(date?.getTime());
@@ -273,7 +276,9 @@ describe('x-axis tab', () => {
         await userEvent.click(shortcutButton);
 
         const date = state.search?.searchParams.dateRange.toDate
-          ? new Date(state.search.searchParams.dateRange.toDate)
+          ? convertApiTimestampToDate(
+              state.search?.searchParams.dateRange.toDate
+            )
           : null;
 
         expect(changeXMaximum).toHaveBeenCalledWith(date?.getTime());

--- a/src/plotting/plotSettings/xAxisTab.component.tsx
+++ b/src/plotting/plotSettings/xAxisTab.component.tsx
@@ -34,7 +34,7 @@ import {
   type SelectedPlotChannel,
 } from '../../app.types';
 import { useAppSelector } from '../../state/hooks';
-import { selectSearchParams } from '../../state/slices/searchSlice';
+import { selectDateRangeInLocalTime } from '../../state/slices/searchSlice';
 import PlotSettingsTextField from './plotSettingsTextField.component';
 
 const StyledClose = styled(Close)(() => ({
@@ -100,7 +100,7 @@ const XAxisTab = (props: XAxisTabProps) => {
     selectedPlotChannels,
   } = props;
 
-  const { dateRange } = useAppSelector(selectSearchParams);
+  const dateRange = useAppSelector(selectDateRangeInLocalTime);
   // We define these as strings so the user can type decimal points
   // We then attempt to parse numbers from them whenever their values change
   const [xMinimum, setXMinimum] = React.useState<string>(
@@ -274,9 +274,7 @@ const XAxisTab = (props: XAxisTabProps) => {
                         {
                           label: 'Jump to start of search range',
                           getValue: () => {
-                            return dateRange.fromDate
-                              ? new Date(dateRange.fromDate)
-                              : null;
+                            return dateRange.fromDate ?? null;
                           },
                         },
                       ],
@@ -360,9 +358,7 @@ const XAxisTab = (props: XAxisTabProps) => {
                         {
                           label: 'Jump to end of search range',
                           getValue: () => {
-                            return dateRange.toDate
-                              ? new Date(dateRange.toDate)
-                              : null;
+                            return dateRange.toDate ?? null;
                           },
                         },
                       ],

--- a/src/search/components/dateTime.component.tsx
+++ b/src/search/components/dateTime.component.tsx
@@ -20,7 +20,7 @@ import { isAfter, isBefore, isEqual, isValid } from 'date-fns';
 import { enGB } from 'date-fns/locale';
 import React from 'react';
 import { FLASH_ANIMATION } from '../../animation';
-import { convertApiTimestampToDate } from '../../api/records';
+import { convertApiTimestampToDate } from '../../api/api';
 import { ExperimentParams } from '../../app.types';
 import { TimeframeRange } from './timeframe.component';
 

--- a/src/search/components/dateTime.component.tsx
+++ b/src/search/components/dateTime.component.tsx
@@ -20,6 +20,7 @@ import { isAfter, isBefore, isEqual, isValid } from 'date-fns';
 import { enGB } from 'date-fns/locale';
 import React from 'react';
 import { FLASH_ANIMATION } from '../../animation';
+import { convertApiTimestampToDate } from '../../api/records';
 import { ExperimentParams } from '../../app.types';
 import { TimeframeRange } from './timeframe.component';
 
@@ -85,9 +86,9 @@ export const renderExperimentPickerDay = (
     return <PickersDay {...pickersDayProps} />;
   }
 
-  const start = new Date(experimentRange.start_date);
+  const start = convertApiTimestampToDate(experimentRange.start_date);
   start.setHours(0, 0, 0, 0);
-  const end = new Date(experimentRange.end_date);
+  const end = convertApiTimestampToDate(experimentRange.end_date);
   const currentDate = new Date(date);
   const dayIsBetween = date >= start && date <= end;
   const isFirstDay = currentDate.getDate() === start.getDate();

--- a/src/search/searchBar.component.test.tsx
+++ b/src/search/searchBar.component.test.tsx
@@ -9,9 +9,9 @@ import {
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import React from 'react';
+import { formatDateTimeForApi } from '../api/api';
 import recordsJson from '../mocks/records.json';
 import { server } from '../mocks/server';
-import { formatDateTimeForApi } from '../state/slices/searchSlice';
 import { RootState } from '../state/store';
 import { getInitialState, renderComponentWithProviders } from '../testUtils';
 import { MAX_SHOTS_VALUES } from './components/maxShots.component';

--- a/src/search/searchBar.component.tsx
+++ b/src/search/searchBar.component.tsx
@@ -10,9 +10,9 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { isBefore, sub } from 'date-fns';
 import React from 'react';
+import { convertApiTimestampToDate, formatDateTimeForApi } from '../api/api';
 import { useExperiment } from '../api/experiment';
 import {
-  convertApiTimestampToDate,
   useDateToShotnumConverter,
   useIncomingRecordCount,
   useShotnumToDateConverter,
@@ -28,7 +28,6 @@ import { selectRecordLimitWarning } from '../state/slices/configSlice';
 import { selectQueryFilters } from '../state/slices/filterSlice';
 import {
   changeSearchParams,
-  formatDateTimeForApi,
   selectDateRangeInLocalTime,
   selectSearchParams,
 } from '../state/slices/searchSlice';

--- a/src/search/searchBar.component.tsx
+++ b/src/search/searchBar.component.tsx
@@ -12,6 +12,7 @@ import { isBefore, sub } from 'date-fns';
 import React from 'react';
 import { useExperiment } from '../api/experiment';
 import {
+  convertApiTimestampToDate,
   useDateToShotnumConverter,
   useIncomingRecordCount,
   useShotnumToDateConverter,
@@ -28,6 +29,7 @@ import { selectQueryFilters } from '../state/slices/filterSlice';
 import {
   changeSearchParams,
   formatDateTimeForApi,
+  selectDateRangeInLocalTime,
   selectSearchParams,
 } from '../state/slices/searchSlice';
 import AutoRefreshToggle from './components/autoRefreshToggle.component';
@@ -56,12 +58,8 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
   const { expanded, sessionId, heightRef } = props;
 
   const searchParams = useAppSelector(selectSearchParams); // the parameters sent to the search query itself
-  const {
-    dateRange,
-    shotnumRange,
-    maxShots: maxShotsParam,
-    experimentID,
-  } = searchParams;
+  const { shotnumRange, maxShots: maxShotsParam, experimentID } = searchParams;
+  const dateRangeLocalTime = useAppSelector(selectDateRangeInLocalTime);
 
   // we need filters so we can check for past queries before showing the warning message
   const filters = useAppSelector(selectQueryFilters);
@@ -73,13 +71,9 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
   // ########################
   // The FROM and TO dates sent as part of the query (if any)
   const [searchParameterFromDate, setSearchParameterFromDate] =
-    React.useState<Date | null>(
-      dateRange.fromDate ? new Date(dateRange.fromDate) : null
-    );
+    React.useState<Date | null>(dateRangeLocalTime.fromDate ?? null);
   const [searchParameterToDate, setSearchParameterToDate] =
-    React.useState<Date | null>(
-      dateRange.toDate ? new Date(dateRange.toDate) : null
-    );
+    React.useState<Date | null>(dateRangeLocalTime.toDate ?? null);
 
   // set seconds to 0 for searchParameterFromDate
   if (searchParameterFromDate) {
@@ -166,8 +160,8 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
   const calculateExperimentDateRange = (
     experiment: ExperimentParams
   ): { from: Date; to: Date } => {
-    const to = new Date(experiment.end_date);
-    const from = new Date(experiment.start_date);
+    const to = convertApiTimestampToDate(experiment.end_date);
+    const from = convertApiTimestampToDate(experiment.start_date);
 
     return { from, to };
   };
@@ -190,8 +184,8 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
     dateTime: Date,
     experiment: ExperimentParams
   ): boolean => {
-    const startDate = new Date(experiment.start_date);
-    const endDate = new Date(experiment.end_date);
+    const startDate = convertApiTimestampToDate(experiment.start_date);
+    const endDate = convertApiTimestampToDate(experiment.end_date);
     return dateTime >= startDate && dateTime <= endDate;
   };
 
@@ -262,8 +256,10 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
     // and if a time frame range exist it clears the time frame range
     if (!dateToShotnum && !!shotnumToDate) {
       if (shotnumToDate.from && shotnumToDate.to) {
-        const shotnumToDateFromDate = new Date(shotnumToDate.from);
-        const shotnumToDateToDate = new Date(shotnumToDate.to);
+        const shotnumToDateFromDate = convertApiTimestampToDate(
+          shotnumToDate.from
+        );
+        const shotnumToDateToDate = convertApiTimestampToDate(shotnumToDate.to);
         setSearchParameterFromDate(shotnumToDateFromDate);
         setSearchParameterToDate(shotnumToDateToDate);
         if (timeframeRange) {
@@ -304,16 +300,8 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
   // Updates the search fields when a session is loaded
   // also just generally ensures we're synced with the store
   React.useEffect(() => {
-    setSearchParameterFromDate(
-      typeof dateRange.fromDate !== 'undefined'
-        ? new Date(dateRange.fromDate)
-        : null
-    );
-    setSearchParameterToDate(
-      typeof dateRange.toDate !== 'undefined'
-        ? new Date(dateRange.toDate)
-        : null
-    );
+    setSearchParameterFromDate(dateRangeLocalTime.fromDate ?? null);
+    setSearchParameterToDate(dateRangeLocalTime.toDate ?? null);
 
     setSearchParameterExperiment(experimentID);
 
@@ -322,7 +310,7 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
 
     setMaxShots(maxShotsParam);
     setParamsUpdated(false);
-  }, [dateRange, experimentID, maxShotsParam, shotnumRange]);
+  }, [dateRangeLocalTime, experimentID, maxShotsParam, shotnumRange]);
 
   const firstUpdate = React.useRef(true);
   // use a ref so that we can control the useEffect that's supposed to

--- a/src/session/sessionDrawer.component.tsx
+++ b/src/session/sessionDrawer.component.tsx
@@ -14,7 +14,7 @@ import {
 } from '@mui/material';
 import Drawer from '@mui/material/Drawer';
 import React from 'react';
-import { convertApiTimestampToDate } from '../api/records';
+import { convertApiTimestampToDate } from '../api/api';
 import { SessionListItem, SessionResponse } from '../app.types';
 import { useAppDispatch } from '../state/hooks';
 import { importSession } from '../state/store';

--- a/src/session/sessionDrawer.component.tsx
+++ b/src/session/sessionDrawer.component.tsx
@@ -14,6 +14,7 @@ import {
 } from '@mui/material';
 import Drawer from '@mui/material/Drawer';
 import React from 'react';
+import { convertApiTimestampToDate } from '../api/records';
 import { SessionListItem, SessionResponse } from '../app.types';
 import { useAppDispatch } from '../state/hooks';
 import { importSession } from '../state/store';
@@ -48,7 +49,10 @@ interface SessionListElementProps extends SessionListItem {
 function compareSessions(a: SessionListItem, b: SessionListItem): number {
   if (a.auto_saved === b.auto_saved) {
     // If auto_saved is the same, sort by timestamp (you can adjust the sorting criteria)
-    return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+    return (
+      convertApiTimestampToDate(b.timestamp).getTime() -
+      convertApiTimestampToDate(a.timestamp).getTime()
+    );
   }
   // Sort auto_saved=true sessions above auto_saved=false sessions
   return b.auto_saved ? 1 : -1;

--- a/src/session/sessionSaveButtons.component.tsx
+++ b/src/session/sessionSaveButtons.component.tsx
@@ -1,9 +1,10 @@
 import { Button, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import type { AxiosError } from 'axios';
-import { format, parseISO } from 'date-fns';
+import { format } from 'date-fns';
 import React from 'react';
 import { shallowEqual } from 'react-redux';
+import { convertApiTimestampToDate } from '../api/records';
 import { useEditSession, useSaveSession } from '../api/sessions';
 import { SessionResponse, type SessionListItem } from '../app.types';
 import handleOG_APIError from '../handleOG_APIError';
@@ -30,7 +31,7 @@ export interface SessionsSaveButtonsProps {
 export const AUTO_SAVE_INTERVAL_MS = 5 * 60 * 1000;
 
 const formatDate = (inputDate: string) => {
-  const date = parseISO(inputDate);
+  const date = convertApiTimestampToDate(inputDate);
   const formattedDate = format(date, 'dd MMM yyyy HH:mm');
   return formattedDate;
 };

--- a/src/session/sessionSaveButtons.component.tsx
+++ b/src/session/sessionSaveButtons.component.tsx
@@ -4,7 +4,7 @@ import type { AxiosError } from 'axios';
 import { format } from 'date-fns';
 import React from 'react';
 import { shallowEqual } from 'react-redux';
-import { convertApiTimestampToDate } from '../api/records';
+import { convertApiTimestampToDate } from '../api/api';
 import { useEditSession, useSaveSession } from '../api/sessions';
 import { SessionResponse, type SessionListItem } from '../app.types';
 import handleOG_APIError from '../handleOG_APIError';

--- a/src/state/slices/searchSlice.test.tsx
+++ b/src/state/slices/searchSlice.test.tsx
@@ -1,9 +1,33 @@
-import { formatDateTimeForApi } from './searchSlice';
+import { initialStateFunc, selectDateRangeInLocalTime } from './searchSlice';
 
-describe('formatDateTimeForApi', () => {
-  it('returns a correctly formatted string', () => {
-    const testDate = new Date('2022-01-01 00:00:00');
-    const result = formatDateTimeForApi(testDate);
-    expect(result).toEqual('2022-01-01T00:00:00');
+describe('Selectors', () => {
+  let state: { search: ReturnType<typeof initialStateFunc> };
+
+  beforeEach(() => {
+    state = { search: initialStateFunc() };
+    vi.stubEnv('TZ', 'Etc/GMT-1'); // POSIX timezone so this is "opposite" so this is UTC+1 aka BST
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('selectDateRangeInLocalTime converts API string to local JS date objects', () => {
+    state = {
+      search: {
+        searchParams: {
+          ...state.search.searchParams,
+          dateRange: {
+            fromDate: '2025-09-21T10:00:00',
+            toDate: '2025-09-21T11:00:00',
+          },
+        },
+      },
+    };
+
+    expect(selectDateRangeInLocalTime(state)).toEqual({
+      fromDate: new Date('2025-09-21 11:00:00'),
+      toDate: new Date('2025-09-21 12:00:00'),
+    });
   });
 });

--- a/src/state/slices/searchSlice.tsx
+++ b/src/state/slices/searchSlice.tsx
@@ -1,18 +1,13 @@
-import { tz } from '@date-fns/tz';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSelector, createSlice } from '@reduxjs/toolkit';
-import { format, sub } from 'date-fns';
-import { convertApiTimestampToDate } from '../../api/records';
+import { sub } from 'date-fns';
+import { convertApiTimestampToDate, formatDateTimeForApi } from '../../api/api';
 import { SearchParams } from '../../app.types';
 import { MAX_SHOTS_VALUES } from '../../search/components/maxShots.component';
 import { RootState } from '../store';
 import { selectQueryFilters } from './filterSlice';
 import { selectQueryFunctions } from './functionsSlice';
 import { selectPage, selectResultsPerPage, selectSort } from './tableSlice';
-
-export const formatDateTimeForApi = (datetime: Date): string => {
-  return format(datetime, "yyyy-MM-dd'T'HH:mm:ss", { in: tz('UTC') });
-};
 
 // Define a type for the slice state
 interface SearchState {

--- a/src/state/slices/searchSlice.tsx
+++ b/src/state/slices/searchSlice.tsx
@@ -1,6 +1,8 @@
+import { tz } from '@date-fns/tz';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSelector, createSlice } from '@reduxjs/toolkit';
 import { format, sub } from 'date-fns';
+import { convertApiTimestampToDate } from '../../api/records';
 import { SearchParams } from '../../app.types';
 import { MAX_SHOTS_VALUES } from '../../search/components/maxShots.component';
 import { RootState } from '../store';
@@ -9,10 +11,7 @@ import { selectQueryFunctions } from './functionsSlice';
 import { selectPage, selectResultsPerPage, selectSort } from './tableSlice';
 
 export const formatDateTimeForApi = (datetime: Date): string => {
-  const dateString = format(datetime, 'yyyy-MM-dd');
-  const timeString = format(datetime, 'HH:mm:ss');
-
-  return `${dateString}T${timeString}`;
+  return format(datetime, "yyyy-MM-dd'T'HH:mm:ss", { in: tz('UTC') });
 };
 
 // Define a type for the slice state
@@ -60,6 +59,21 @@ export const { changeSearchParams } = searchSlice.actions;
 // Other code such as selectors can use the imported `RootState` type
 export const selectSearchParams = (state: RootState) =>
   state.search.searchParams;
+
+const selectSearchDateRange = (state: RootState) =>
+  state.search.searchParams.dateRange;
+
+export const selectDateRangeInLocalTime = createSelector(
+  selectSearchDateRange,
+  (dateRange) => ({
+    fromDate: dateRange.fromDate
+      ? convertApiTimestampToDate(dateRange.fromDate)
+      : undefined,
+    toDate: dateRange.toDate
+      ? convertApiTimestampToDate(dateRange.toDate)
+      : undefined,
+  })
+);
 
 export const selectQueryParams = createSelector(
   selectSearchParams,

--- a/src/table/cellRenderers/cellContentRenderers.tsx
+++ b/src/table/cellRenderers/cellContentRenderers.tsx
@@ -1,6 +1,6 @@
 import { format, isValid } from 'date-fns';
 import React from 'react';
-import { convertApiTimestampToDate } from '../../api/records';
+import { convertApiTimestampToDate } from '../../api/api';
 
 export const roundNumber = (
   num: number,

--- a/src/table/cellRenderers/cellContentRenderers.tsx
+++ b/src/table/cellRenderers/cellContentRenderers.tsx
@@ -1,5 +1,6 @@
-import { format, isValid, parseISO } from 'date-fns';
+import { format, isValid } from 'date-fns';
 import React from 'react';
+import { convertApiTimestampToDate } from '../../api/records';
 
 export const roundNumber = (
   num: number,
@@ -50,7 +51,7 @@ export const Base64ImageThumbnail = React.forwardRef(
 Base64ImageThumbnail.displayName = 'Base64ImageThumbnail';
 
 export const renderTimestamp = (serverTimestamp: string) => {
-  const date = parseISO(serverTimestamp);
+  const date = convertApiTimestampToDate(serverTimestamp);
   if (isValid(date)) {
     return format(date, 'yyyy-MM-dd HH:mm:ss');
   } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,6 +356,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@date-fns/tz@npm:1.4.1":
+  version: 1.4.1
+  resolution: "@date-fns/tz@npm:1.4.1"
+  checksum: 10c0/9033fdc4682fe3d4d147625ce04fa88a8792653594e2de8d5a438c8f3bfc0990ee28fe773f91cac6810b06d818b5b281ae0608752ba8337257d0279ded3f019a
+  languageName: node
+  linkType: hard
+
 "@date-io/core@npm:^3.2.0":
   version: 3.2.0
   resolution: "@date-io/core@npm:3.2.0"
@@ -363,17 +370,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@date-io/date-fns@npm:3.2.0":
-  version: 3.2.0
-  resolution: "@date-io/date-fns@npm:3.2.0"
+"@date-io/date-fns@npm:3.2.1":
+  version: 3.2.1
+  resolution: "@date-io/date-fns@npm:3.2.1"
   dependencies:
     "@date-io/core": "npm:^3.2.0"
   peerDependencies:
-    date-fns: ^3.2.0
+    date-fns: ^3.2.0 || ^4.1.0
   peerDependenciesMeta:
     date-fns:
       optional: true
-  checksum: 10c0/f618e5669ae6add13e092f0479d213e4e4a88084c06c578b7e7e47ef956acfbb2d6732bb57c778572893620579ebbbe0bd5fea90f3dbc4e987a43394a8f265e1
+  checksum: 10c0/fe489ce51599264ec6d0e64d0a1675220cea4123568320fe58c2c6e8f2b6cea0124e4ee7fccfbc905173bd98b841948cde1030023517da8ed2d54a133513e19d
   languageName: node
   linkType: hard
 
@@ -3606,10 +3613,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:3.6.0":
-  version: 3.6.0
-  resolution: "date-fns@npm:3.6.0"
-  checksum: 10c0/0b5fb981590ef2f8e5a3ba6cd6d77faece0ea7f7158948f2eaae7bbb7c80a8f63ae30b01236c2923cf89bb3719c33aeb150c715ea4fe4e86e37dcf06bed42fb6
+"date-fns@npm:4.1.0":
+  version: 4.1.0
+  resolution: "date-fns@npm:4.1.0"
+  checksum: 10c0/b79ff32830e6b7faa009590af6ae0fb8c3fd9ffad46d930548fbb5acf473773b4712ae887e156ba91a7b3dc30591ce0f517d69fd83bd9c38650fdc03b4e0bac8
   languageName: node
   linkType: hard
 
@@ -6908,7 +6915,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "operationsgateway@workspace:."
   dependencies:
-    "@date-io/date-fns": "npm:3.2.0"
+    "@date-fns/tz": "npm:1.4.1"
+    "@date-io/date-fns": "npm:3.2.1"
     "@dotenvx/dotenvx": "npm:1.48.4"
     "@emotion/cache": "npm:11.14.0"
     "@emotion/react": "npm:11.14.0"
@@ -6944,7 +6952,7 @@ __metadata:
     cross-env: "npm:7.0.3"
     cypress: "npm:14.5.3"
     cypress-delete-downloads-folder: "npm:0.0.5"
-    date-fns: "npm:3.6.0"
+    date-fns: "npm:4.1.0"
     eslint: "npm:9.29.0"
     eslint-config-prettier: "npm:10.1.1"
     eslint-plugin-cypress: "npm:4.3.0"


### PR DESCRIPTION
## Description
Ensure that we only send UTC timestamps to the API (needed an upgrade of date-fns to v4 to use their new timezone support to format it nicely) and ensure we always parse API timestamps as UTC - to ensure this I've tried to make a centralised util function convertAPITimestampToDate to handle converting an API timestamp string to a JS Date. To test this, you'll need to look at the requests to see that currently because we're in BST all timestamps sent/received from the API are 1 hour earlier than displayed. Whereas all displayed timestamps should be in the current time/BST.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Check against preprod to check API handling

## Agile board tracking
Closes DSEGOG-442
