### PR TITLE
DSEGOG-443 Fix refresh bug

### DIFF
--- a/cypress/e2e/search.cy.ts
+++ b/cypress/e2e/search.cy.ts
@@ -298,6 +298,17 @@ describe('Search', () => {
       });
 
       it('refreshes datetime stamps and launches search if timeframe is set and refresh button clicked', () => {
+        cy.window().then(async (window) => {
+          // Reference global instances set in "src/mocks/browser.js".
+          const { worker, http } = window.msw;
+
+          worker.use(
+            http.get('/records/range_converter?date_range', () =>
+              HttpResponse.json({ min: 9, max: 11 }, { status: 200 })
+            )
+          );
+        });
+
         // Set a relative timestamp and verify the initial seach is correct
         cy.findByLabelText('open timeframe search box').click();
         cy.findByRole('button', { name: 'Last 10 mins' }).click();
@@ -307,6 +318,18 @@ describe('Search', () => {
         const expectedToDateString = formatDateTimeForApi(expectedToDate);
         const expectedFromDateString = formatDateTimeForApi(expectedFromDate);
 
+        const formatDateForDatePicker = (date) =>
+          date.toLocaleString('sv-SE').split(':').slice(0, 2).join(':');
+
+        cy.findByLabelText('from, date-time input').should(
+          'have.value',
+          formatDateForDatePicker(expectedFromDate)
+        );
+        cy.findByLabelText('to, date-time input').should(
+          'have.value',
+          formatDateForDatePicker(expectedToDate)
+        );
+
         // close to ensure not covering search button
         cy.findByLabelText('close timeframe search box').click();
 
@@ -315,6 +338,7 @@ describe('Search', () => {
         cy.findByRole('button', { name: 'Search' }).click();
 
         // wait for search to finish
+        cy.findByRole('progressbar').should('exist');
         cy.findByRole('progressbar').should('not.exist');
 
         cy.findBrowserMockedRequests({ method: 'GET', url: '/records' }).should(
@@ -347,6 +371,7 @@ describe('Search', () => {
         cy.findByLabelText('Refresh data').click();
 
         // wait for search to finish
+        cy.findByRole('progressbar').should('exist');
         cy.findByRole('progressbar').should('not.exist');
 
         const newExpectedToDate = new Date('1970-01-08 01:01:59');
@@ -354,6 +379,124 @@ describe('Search', () => {
         const newExpectedToDateString = formatDateTimeForApi(newExpectedToDate);
         const newExpectedFromDateString =
           formatDateTimeForApi(newExpectedFromDate);
+
+        cy.findByLabelText('from, date-time input').should(
+          'have.value',
+          formatDateForDatePicker(newExpectedFromDate)
+        );
+        cy.findByLabelText('to, date-time input').should(
+          'have.value',
+          formatDateForDatePicker(newExpectedToDate)
+        );
+        cy.findByRole('button', { name: 'Refresh data' }).should('be.enabled');
+
+        cy.findBrowserMockedRequests({ method: 'GET', url: '/records' }).should(
+          (patchRequests) => {
+            expect(patchRequests.length).equal(1);
+            const request = patchRequests[0];
+
+            expect(request.url.toString()).to.contain('conditions=');
+            const paramMap: Map<string, string> = getParamsFromUrl(
+              request.url.toString()
+            );
+            const conditionsMap = getConditionsFromParams(paramMap);
+            expect(conditionsMap.length).equal(1);
+
+            const condition = conditionsMap[0];
+            const timestampRange = condition['metadata.timestamp'];
+
+            const gte: string = timestampRange['$gte'];
+            const lte: string = timestampRange['$lte'];
+
+            // Check that the new datetime stamps have each moved forward a minute
+            expect(gte).equal(newExpectedFromDateString);
+            expect(lte).equal(newExpectedToDateString);
+          }
+        );
+      });
+
+      it('refreshes datetime stamps and launches search if timeframe is set and refresh button clicked even if date -> shot number fails', () => {
+        // Set a relative timestamp and verify the initial seach is correct
+        cy.findByLabelText('open timeframe search box').click();
+        cy.findByRole('button', { name: 'Last 10 mins' }).click();
+
+        const expectedToDate = new Date('1970-01-08 01:00:59');
+        const expectedFromDate = new Date('1970-01-08 00:50:00');
+        const expectedToDateString = formatDateTimeForApi(expectedToDate);
+        const expectedFromDateString = formatDateTimeForApi(expectedFromDate);
+
+        const formatDateForDatePicker = (date) =>
+          date.toLocaleString('sv-SE').split(':').slice(0, 2).join(':');
+
+        cy.findByLabelText('from, date-time input').should(
+          'have.value',
+          formatDateForDatePicker(expectedFromDate)
+        );
+        cy.findByLabelText('to, date-time input').should(
+          'have.value',
+          formatDateForDatePicker(expectedToDate)
+        );
+
+        // close to ensure not covering search button
+        cy.findByLabelText('close timeframe search box').click();
+
+        cy.startSnoopingBrowserMockedRequest();
+
+        cy.findByRole('button', { name: 'Search' }).click();
+
+        // wait for search to finish
+        cy.findByRole('progressbar').should('exist');
+        cy.findByRole('progressbar').should('not.exist');
+
+        cy.findBrowserMockedRequests({ method: 'GET', url: '/records' }).should(
+          (patchRequests) => {
+            expect(patchRequests.length).equal(1);
+            const request = patchRequests[0];
+
+            expect(request.url.toString()).to.contain('conditions=');
+            const paramMap: Map<string, string> = getParamsFromUrl(
+              request.url.toString()
+            );
+            const conditionsMap = getConditionsFromParams(paramMap);
+            expect(conditionsMap.length).equal(1);
+
+            const condition = conditionsMap[0];
+            const timestampRange = condition['metadata.timestamp'];
+
+            const gte: string = timestampRange['$gte'];
+            const lte: string = timestampRange['$lte'];
+            expect(gte).equal(expectedFromDateString);
+            expect(lte).equal(expectedToDateString);
+          }
+        );
+
+        cy.clearMocks();
+
+        // Advance time forward a minute
+        cy.tick(60000);
+
+        cy.findByLabelText('Refresh data').click();
+
+        // wait for search to finish
+        cy.findByRole('progressbar', { timeout: 15_000 }).should('exist');
+        cy.findByRole('progressbar').should('not.exist');
+
+        const newExpectedToDate = new Date('1970-01-08 01:01:59');
+        const newExpectedFromDate = new Date('1970-01-08 00:51:00');
+        const newExpectedToDateString = formatDateTimeForApi(newExpectedToDate);
+        const newExpectedFromDateString =
+          formatDateTimeForApi(newExpectedFromDate);
+
+        cy.findByLabelText('from, date-time input').should(
+          'have.value',
+          formatDateForDatePicker(newExpectedFromDate)
+        );
+        cy.findByLabelText('to, date-time input').should(
+          'have.value',
+          formatDateForDatePicker(newExpectedToDate)
+        );
+        cy.findByRole('button', { name: 'Refresh data' }).should('be.enabled');
+
         cy.findBrowserMockedRequests({ method: 'GET', url: '/records' }).should(
           (patchRequests) => {
             expect(patchRequests.length).equal(1);

--- a/src/search/searchBar.component.test.tsx
+++ b/src/search/searchBar.component.test.tsx
@@ -845,6 +845,31 @@ describe('searchBar component', () => {
       const expectedToDate = new Date('2022-01-11 00:05:59');
       const expectedFromDate = new Date('2022-01-10 23:55:00');
       await user.click(screen.getByLabelText('close timeframe search box'));
+
+      expect(
+        await within(
+          screen.getByLabelText('open shot number search box')
+        ).findByText('9 to 9')
+      ).toBeInTheDocument();
+
+      // mock getting a new response from the date -> shotnum converter
+      server.use(
+        http.get(
+          '/records/range_converter',
+          () =>
+            HttpResponse.json(
+              {
+                from: formatDateTimeForApi(expectedFromDate),
+                to: formatDateTimeForApi(expectedToDate),
+                min: 10,
+                max: 11,
+              },
+              { status: 200 }
+            ),
+          { once: true }
+        )
+      );
+
       await user.click(screen.getByRole('button', { name: 'Search' }));
 
       // wait for search to complete updating the store
@@ -858,10 +883,7 @@ describe('searchBar component', () => {
       );
 
       // Mock a new date constructor to simulate time moving forward a minute
-
-      // act(() => {
       vi.setSystemTime(new Date('2022-01-11 00:06'));
-      // });
 
       await user.click(screen.getByRole('button', { name: 'Refresh data' }));
       const newExpectedToDate = new Date('2022-01-11 00:06:59');
@@ -877,6 +899,87 @@ describe('searchBar component', () => {
       expect(store.getState().search.searchParams.dateRange.toDate).toEqual(
         formatDateTimeForApi(newExpectedToDate)
       );
+      expect(
+        await within(
+          screen.getByLabelText('open shot number search box')
+        ).findByText('10 to 11')
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', { name: 'Refresh data' })
+      ).toBeEnabled();
+    });
+
+    it('refreshes datetime stamps and launches search if timeframe is set and refresh button clicked if date -> shotnum converter fails', async () => {
+      const state = getInitialState();
+      const { store } = createView(state);
+
+      // Set a relative timestamp and verify the initial search is correct
+
+      await user.click(screen.getByLabelText('open timeframe search box'));
+      const timeframePopup = screen.getByRole('dialog');
+      await user.click(
+        within(timeframePopup).getByRole('button', {
+          name: 'Last 10 mins',
+        })
+      );
+      const expectedToDate = new Date('2022-01-11 00:05:59');
+      const expectedFromDate = new Date('2022-01-10 23:55:00');
+      await user.click(screen.getByLabelText('close timeframe search box'));
+
+      expect(
+        await within(
+          screen.getByLabelText('open shot number search box')
+        ).findByText('9 to 9')
+      ).toBeInTheDocument();
+
+      // mock getting a new response from the date -> shotnum converter
+      server.use(
+        http.get(
+          '/records/range_converter',
+          () => HttpResponse.json(undefined, { status: 500 }),
+          { once: true }
+        )
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Search' }));
+
+      // wait for search to complete updating the store
+      await waitFor(() =>
+        expect(store.getState().search.searchParams.dateRange.fromDate).toEqual(
+          formatDateTimeForApi(expectedFromDate)
+        )
+      );
+      expect(store.getState().search.searchParams.dateRange.toDate).toEqual(
+        formatDateTimeForApi(expectedToDate)
+      );
+
+      // Mock a new date constructor to simulate time moving forward a minute
+      vi.setSystemTime(new Date('2022-01-11 00:06'));
+
+      await user.click(screen.getByRole('button', { name: 'Refresh data' }));
+      const newExpectedToDate = new Date('2022-01-11 00:06:59');
+      const newExpectedFromDate = new Date('2022-01-10 23:56:00');
+
+      // Check that the new datetime stamps have each moved forward a minute
+
+      await waitFor(() =>
+        expect(store.getState().search.searchParams.dateRange.fromDate).toEqual(
+          formatDateTimeForApi(newExpectedFromDate)
+        )
+      );
+      expect(store.getState().search.searchParams.dateRange.toDate).toEqual(
+        formatDateTimeForApi(newExpectedToDate)
+      );
+      expect(
+        await within(
+          screen.getByLabelText('open shot number search box')
+        ).findByText('Select')
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', { name: 'Refresh data' })
+      ).toBeEnabled();
     });
   });
 

--- a/src/search/searchBar.component.tsx
+++ b/src/search/searchBar.component.tsx
@@ -8,7 +8,7 @@ import {
   Typography,
 } from '@mui/material';
 import { useQueryClient } from '@tanstack/react-query';
-import { isBefore, sub } from 'date-fns';
+import { isBefore, isEqual, sub } from 'date-fns';
 import React from 'react';
 import { useExperiment } from '../api/experiment';
 import {
@@ -52,6 +52,9 @@ interface SearchBarProps {
 }
 
 const SearchBar = (props: SearchBarProps): React.ReactElement => {
+  // @ts-expect-error testing
+  window.isEqual = isEqual;
+
   const dispatch = useAppDispatch();
   const { expanded, sessionId, heightRef } = props;
 
@@ -114,8 +117,10 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
   ): { from: Date; to: Date } => {
     const to = new Date();
     to.setSeconds(59);
+    to.setMilliseconds(0);
     const from = sub(new Date(to), { [timeframe.timescale]: timeframe.value });
     from.setSeconds(0);
+    from.setMilliseconds(0);
 
     return { from, to };
   };
@@ -480,8 +485,22 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
   const [refreshingData, setRefreshingData] = React.useState<boolean>(false);
 
   const refreshData = () => {
-    setExperimentTimeframe(searchParameterExperiment);
     setRelativeTimeframe(timeframeRange);
+    // make sure we clear shot numbers when the date range changes via a refresh
+    // as otherwise the shotnum -> date conversion will be run and clear the timeframe
+    // the shot numbers will be correctly set by the date -> shotnum code when
+    // the refresh is finished
+    if (timeframeRange && searchParameterToDate && searchParameterFromDate) {
+      const newTimeFrame = calculateTimeframeDateRange(timeframeRange);
+
+      if (
+        !isEqual(newTimeFrame.to, searchParameterToDate) ||
+        !isEqual(newTimeFrame.from, searchParameterFromDate)
+      ) {
+        setSearchParameterShotnumMax(undefined);
+        setSearchParameterShotnumMin(undefined);
+      }
+    }
     setRefreshingData(true);
   };
 
@@ -490,7 +509,7 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
       handleSearch();
       setRefreshingData(false);
     }
-  }, [handleSearch, refreshingData]);
+  }, [handleSearch, queryClient, refreshingData]);
 
   return (
     <Collapse in={expanded} timeout="auto" unmountOnExit>

--- a/src/search/searchBar.component.tsx
+++ b/src/search/searchBar.component.tsx
@@ -227,17 +227,18 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
       searchParameterShotnumMax === undefined);
 
   // Date range to shot number range converter
-  const { data: dateToShotnum } = useDateToShotnumConverter(
-    searchParameterFromDate
-      ? formatDateTimeForApi(searchParameterFromDate)
-      : undefined,
-    searchParameterToDate
-      ? formatDateTimeForApi(searchParameterToDate)
-      : undefined,
-    // only enable query when dates are not null and the range is valid
-    !invalidDateRange &&
-      !(searchParameterFromDate === null && searchParameterToDate === null)
-  );
+  const { data: dateToShotnum, isError: dateToShotnumError } =
+    useDateToShotnumConverter(
+      searchParameterFromDate
+        ? formatDateTimeForApi(searchParameterFromDate)
+        : undefined,
+      searchParameterToDate
+        ? formatDateTimeForApi(searchParameterToDate)
+        : undefined,
+      // only enable query when dates are not null and the range is valid
+      !invalidDateRange &&
+        !(searchParameterFromDate === null && searchParameterToDate === null)
+    );
 
   // Shot number range to date range converter
   const { data: shotnumToDate } = useShotnumToDateConverter(
@@ -256,6 +257,8 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
 
   const [isShotnumToDate, setIsShotnumToDate] = React.useState<boolean>(false);
   const [isDateToShotnum, setIsDateToShotnum] = React.useState<boolean>(false);
+  const [timeFrameChangedAfterRefresh, setTimeFrameChangedAfterRefresh] =
+    React.useState<boolean>(false);
 
   // handles the date range to shot number conversion
   React.useEffect(() => {
@@ -265,7 +268,7 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
     // Additionally if the new shot number range is not within
     // the current experiment id time frame it clears the experiment id
     // and if a time frame range exist it clears the time frame range
-    if (!dateToShotnum && !!shotnumToDate) {
+    if (!timeFrameChangedAfterRefresh && !dateToShotnum && !!shotnumToDate) {
       if (shotnumToDate.from && shotnumToDate.to) {
         const shotnumToDateFromDate = new Date(shotnumToDate.from);
         const shotnumToDateToDate = new Date(shotnumToDate.to);
@@ -294,15 +297,28 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
       // Sets the shot number range when the date Range is selected.
       // the logic for the timeframes and experiment timeframe is done
       // in the dateTime component
-    } else if (!!dateToShotnum && !shotnumToDate) {
+    } else if (
+      (timeFrameChangedAfterRefresh || !shotnumToDate) &&
+      !!dateToShotnum
+    ) {
       setSearchParameterShotnumMin(dateToShotnum.min);
       setSearchParameterShotnumMax(dateToShotnum.max);
+      if (timeFrameChangedAfterRefresh) {
+        setTimeFrameChangedAfterRefresh(false);
+      }
+      // if date range -> shot number conversion fails, we still need to reset timeFrameChangedAfterRefresh and shot numbers
+    } else if (timeFrameChangedAfterRefresh && dateToShotnumError) {
+      setSearchParameterShotnumMax(undefined);
+      setSearchParameterShotnumMin(undefined);
+      setTimeFrameChangedAfterRefresh(false);
     }
   }, [
     dateToShotnum,
+    dateToShotnumError,
     searchParameterExperiment,
     setExperimentTimeframe,
     shotnumToDate,
+    timeFrameChangedAfterRefresh,
     timeframeRange,
   ]);
 
@@ -486,10 +502,10 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
 
   const refreshData = () => {
     setRelativeTimeframe(timeframeRange);
-    // make sure we clear shot numbers when the date range changes via a refresh
+    // make sure we set timeFrameChangedAfterRefresh when the date range changes via a refresh
     // as otherwise the shotnum -> date conversion will be run and clear the timeframe
-    // the shot numbers will be correctly set by the date -> shotnum code when
-    // the refresh is finished
+    // the shot numbers will be correctly set by the date -> shotnum code and it also
+    // resets the timeFrameChangedAfterRefresh variable which triggers the new search
     if (timeframeRange && searchParameterToDate && searchParameterFromDate) {
       const newTimeFrame = calculateTimeframeDateRange(timeframeRange);
 
@@ -497,19 +513,19 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
         !isEqual(newTimeFrame.to, searchParameterToDate) ||
         !isEqual(newTimeFrame.from, searchParameterFromDate)
       ) {
-        setSearchParameterShotnumMax(undefined);
-        setSearchParameterShotnumMin(undefined);
+        setTimeFrameChangedAfterRefresh(true);
       }
     }
     setRefreshingData(true);
   };
 
   React.useEffect(() => {
-    if (refreshingData) {
+    // wait for the date to shot number conversion to finish before initiating search
+    if (refreshingData && !timeFrameChangedAfterRefresh) {
       handleSearch();
       setRefreshingData(false);
     }
-  }, [handleSearch, queryClient, refreshingData]);
+  }, [handleSearch, queryClient, refreshingData, timeFrameChangedAfterRefresh]);
 
   return (
     <Collapse in={expanded} timeout="auto" unmountOnExit>


### PR DESCRIPTION
## Description
The refresh basically never worked when the minute changed as the shot number -> date conversion would take priority and wipe out the timeframe. So added a flag state variable to detect when we're in the special "time frame has updated after a refresh state" to disable the shot number -> date range useEffect until the date -> shot number useEffect runs. Also delay committing the search until after the useEffect, this is so that the committed search has the correct shot numbers.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [x] Test auto-refresh against prod data (as that has proper shot numbers and recent data to test)
- [x] Test auto-refresh behaves OK if shot number conversion fails (the search request sent a little late in this case due to react-query auto-retries and back-offs, but this error should be rarer in production I hope... plus eventually it updates the search successfully. Only way to stop this delay would be to stop retries/reduce backoff for the conversion requests)

## Agile board tracking
Closes DSEGOG-443
