### PR TITLE
DSEGOG-466 add unsaved data prompt before plot window closes

### DIFF
--- a/e2e/mocked/plotting.spec.ts
+++ b/e2e/mocked/plotting.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import assert from 'node:assert';
 import type { PlotlyHTMLElement } from 'plotly.js';
 
 test('plots a time vs shotnum graph and change the plot colour', async ({
@@ -732,4 +733,76 @@ test('user can skip non-business hours on a timeseries plot', async ({
 
   const chart = await popup.locator('.plotly-chart');
   await expect(chart).toHaveScreenshot({ maxDiffPixels: 150 });
+});
+
+test('prompts the user to save if plot has unsaved changes', async ({
+  page,
+  browserName,
+}) => {
+  test.skip(
+    browserName === 'firefox',
+    'beforeunload dialog not working on Firefox in playwright'
+  );
+
+  await page.goto('/');
+
+  // MSW wont start immediately here, so wait for page to load first
+  await expect(page.locator('text=Plots')).toBeVisible();
+
+  await page.locator('text=Plots').click();
+
+  // open up popup
+  const [popup] = await Promise.all([
+    page.waitForEvent('popup'),
+    page.locator('text=Create a plot').click(),
+  ]);
+
+  await popup.getByRole('textbox', { name: 'Title' }).fill('my plot');
+
+  popup.on('dialog', async (dialog) => {
+    assert(dialog.type() === 'beforeunload');
+    await dialog.dismiss();
+  });
+  await popup.close({ runBeforeUnload: true });
+
+  await page.waitForTimeout(500);
+
+  // expect popup to remain open
+  await expect(popup.isClosed()).toBe(false);
+
+  // not working atm: see https://github.com/microsoft/playwright/issues/37597
+  // await popup.getByRole('button', { name: 'Save' }).click();
+
+  // await popup.close({ runBeforeUnload: true });
+
+  // await page.waitForTimeout(500);
+
+  // await expect(popup.isClosed()).toBe(true);
+});
+
+test('does not prompt the user to save if plot has no unsaved changes', async ({
+  page,
+}) => {
+  await page.goto('/');
+
+  // MSW wont start immediately here, so wait for page to load first
+  await expect(page.locator('text=Plots')).toBeVisible();
+
+  await page.locator('text=Plots').click();
+
+  // open up popup
+  const [popup] = await Promise.all([
+    page.waitForEvent('popup'),
+    page.locator('text=Create a plot').click(),
+  ]);
+
+  await popup.getByRole('textbox', { name: 'Title' }).fill('my plot');
+  await popup.getByRole('textbox', { name: 'Title' }).fill('Untitled 1');
+
+  await popup.close({ runBeforeUnload: true });
+
+  await page.waitForTimeout(500);
+
+  // expect popup to remain open
+  await expect(popup.isClosed()).toBe(true);
 });

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "browserslist": "4.24.2",
     "browserslist-to-esbuild": "2.1.1",
     "date-fns": "4.1.0",
+    "fast-deep-equal": "3.1.3",
     "hacktimer": "1.1.3",
     "husky": "9.1.1",
     "loglevel": "1.9.1",

--- a/src/plotting/plotWindow.component.tsx
+++ b/src/plotting/plotWindow.component.tsx
@@ -9,10 +9,12 @@ import {
   IconButton,
   Typography,
 } from '@mui/material';
+import deepEqual from 'fast-deep-equal';
 import React from 'react';
 import { useScalarChannels } from '../api/channels';
 import { usePlotRecords } from '../api/records';
 import {
+  DEFAULT_WINDOW_VARS,
   FullScalarChannelMetadata,
   PlotType,
   SelectedPlotChannel,
@@ -148,7 +150,21 @@ const PlotWindow = (props: PlotWindowProps) => {
   const plotAxisSigFigs = useAppSelector(selectPlotAxisSigFigs);
 
   const getPlotConfig: () => PlotConfig = React.useCallback(() => {
-    return {
+    // Capture window size and position
+    const innerWidth =
+      plotWindowRef.current?.state.window?.innerWidth ??
+      DEFAULT_WINDOW_VARS.innerWidth;
+    const innerHeight =
+      plotWindowRef.current?.state.window?.innerHeight ??
+      DEFAULT_WINDOW_VARS.innerHeight;
+    const screenX =
+      plotWindowRef.current?.state.window?.screenX ??
+      DEFAULT_WINDOW_VARS.screenX;
+    const screenY =
+      plotWindowRef.current?.state.window?.screenY ??
+      DEFAULT_WINDOW_VARS.screenY;
+
+    const newPlotConfig = {
       ...plotConfig,
       title: plotTitle,
       plotType,
@@ -169,10 +185,22 @@ const PlotWindow = (props: PlotWindowProps) => {
       axesLabelsVisible,
       selectedColours,
       remainingColours,
+      innerWidth,
+      innerHeight,
+      screenX,
+      screenY,
     };
+    // remove any undefined keys
+    // need to do this to ensure the equality check in onBeforeClose works properly
+    Object.keys(newPlotConfig).forEach(
+      // @ts-expect-error index signature error
+      (key) => newPlotConfig[key] === undefined && delete newPlotConfig[key]
+    );
+    return newPlotConfig;
   }, [
-    plotTitle,
+    plotWindowRef,
     plotConfig,
+    plotTitle,
     plotType,
     XAxis,
     XAxisScale,
@@ -202,11 +230,39 @@ const PlotWindow = (props: PlotWindowProps) => {
       plotWindowRef.current.state.window.getPlotConfig = getPlotConfig;
   }, [getPlotConfig, plotWindowRef]);
 
+  const onBeforeClose = React.useCallback(
+    (e: BeforeUnloadEvent) => {
+      // only check for "actual" config to confirm before saving, ignore window position/size
+      const {
+        innerHeight: currentInnerHeight,
+        innerWidth: currentInnerWidth,
+        screenX: currentScreenX,
+        screenY: currentScreenY,
+        ...currentPlotConfig
+      } = getPlotConfig();
+      const {
+        innerHeight: reduxInnerHeight,
+        innerWidth: reduxInnerWidth,
+        screenX: reduxScreenX,
+        screenY: reduxScreenY,
+        ...reduxPlotConfig
+      } = plotConfig;
+      if (e && !deepEqual(currentPlotConfig, reduxPlotConfig)) {
+        e.preventDefault();
+
+        // for legacy browsers
+        e.returnValue = true;
+      }
+    },
+    [getPlotConfig, plotConfig]
+  );
+
   return (
     <WindowPortal
       ref={plotWindowRef}
       title={plotTitle}
       onClose={onClose}
+      onBeforeClose={onBeforeClose}
       innerWidth={plotConfig.innerWidth}
       innerHeight={plotConfig.innerHeight}
       screenX={plotConfig.screenX}

--- a/src/windows/windowPortal.component.test.tsx
+++ b/src/windows/windowPortal.component.test.tsx
@@ -52,7 +52,7 @@ describe('Window portal component', () => {
 
     expect(newDocument.body).toMatchSnapshot();
     expect(mockAddEventListener).toHaveBeenCalledTimes(1);
-    expect(mockAddEventListener).toHaveBeenCalledWith('beforeunload', onClose);
+    expect(mockAddEventListener).toHaveBeenCalledWith('unload', onClose);
     expect(newDocument.title).toEqual('OperationsGateway Plot - test title');
 
     /* eslint-disable testing-library/no-node-access */
@@ -124,13 +124,35 @@ describe('Window portal component', () => {
       </WindowPortal>
     );
 
+    expect(mockRemoveEventListener).toHaveBeenCalledWith('unload', onClose);
+    expect(mockAddEventListener).toHaveBeenCalledWith('unload', newMockOnClose);
+  });
+
+  it('removed and re-adds event listeners onBeforeClose prop change', () => {
+    const mockOnBeforeClose = vi.fn();
+    props.onBeforeClose = mockOnBeforeClose;
+    const { rerender } = createView();
+
+    expect(mockAddEventListener).toHaveBeenCalledWith(
+      'beforeunload',
+      mockOnBeforeClose
+    );
+
+    const newMockOnBeforeClose = vi.fn();
+
+    rerender(
+      <WindowPortal {...props} onBeforeClose={newMockOnBeforeClose}>
+        <TestComponent />
+      </WindowPortal>
+    );
+
     expect(mockRemoveEventListener).toHaveBeenCalledWith(
       'beforeunload',
-      onClose
+      mockOnBeforeClose
     );
     expect(mockAddEventListener).toHaveBeenCalledWith(
       'beforeunload',
-      newMockOnClose
+      newMockOnBeforeClose
     );
   });
 });

--- a/src/windows/windowPortal.component.tsx
+++ b/src/windows/windowPortal.component.tsx
@@ -23,6 +23,7 @@ interface WindowPortalState {
 export interface WindowPortalProps {
   title?: string;
   onClose: () => void;
+  onBeforeClose?: (e: BeforeUnloadEvent) => void;
   children: React.ReactNode;
   innerWidth: number;
   innerHeight: number;
@@ -174,15 +175,32 @@ export default class WindowPortal extends React.PureComponent<
     prevState: WindowPortalState
   ) {
     if (prevState.window === null && this.state.window) {
-      this.state.window.addEventListener('beforeunload', this.props.onClose);
+      this.state.window.addEventListener('unload', this.props.onClose);
+      if (this.props.onBeforeClose)
+        this.state.window.addEventListener(
+          'beforeunload',
+          this.props.onBeforeClose
+        );
     }
     if (prevProps.title !== this.props.title && this.state.window) {
       // eslint-disable-next-line react/no-direct-mutation-state
       this.state.window.document.title = `OperationsGateway Plot - ${this.props.title}`;
     }
     if (prevProps.onClose !== this.props.onClose) {
-      this.state.window?.removeEventListener('beforeunload', prevProps.onClose);
-      this.state.window?.addEventListener('beforeunload', this.props.onClose);
+      this.state.window?.removeEventListener('unload', prevProps.onClose);
+      this.state.window?.addEventListener('unload', this.props.onClose);
+    }
+    if (prevProps.onBeforeClose !== this.props.onBeforeClose) {
+      if (prevProps.onBeforeClose)
+        this.state.window?.removeEventListener(
+          'beforeunload',
+          prevProps.onBeforeClose
+        );
+      if (this.props.onBeforeClose)
+        this.state.window?.addEventListener(
+          'beforeunload',
+          this.props.onBeforeClose
+        );
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4612,7 +4612,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
+"fast-deep-equal@npm:3.1.3, fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: 10c0/40dedc862eb8992c54579c66d914635afbec43350afbbe991235fdcb4e3a8d5af1b23ae7e79bef7d4882d0ecee06c3197488026998fb19f72dc95acff1d1b1d0
@@ -6963,6 +6963,7 @@ __metadata:
     eslint-plugin-react-hooks: "npm:5.2.0"
     eslint-plugin-testing-library: "npm:7.1.1"
     express: "npm:5.1.0"
+    fast-deep-equal: "npm:3.1.3"
     globals: "npm:16.0.0"
     hacktimer: "npm:1.1.3"
     husky: "npm:9.1.1"


### PR DESCRIPTION
## Description
Utilise the [beforeunload event](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event) dialogue to present the user with a "you have unsaved changes" dialogue before actually closing a plotting window if the current plotting config is different to what is stored in Redux. We already hooked into onBeforeUnload, so move those handlers to onClose to allow for an optional onBeforeUnload handler in windowPortal.

Also, realised that we no longer save window positions when using the plot save button which seems wrong so I added that back. But that would mean that resizing the window would prompt the "unsaved changes" dialogue which I believe is a bit overkill, so I excluded the window params from the equality check to see if there's unsaved changes.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [x] Test that trying to close a plotting window with unsaved changes prompts with a are you sure dialogue (note you have to have interacted with the window in some way, see [documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#usage_notes))
- [x] Test that trying to close a plotting window with no unsaved changes just closes without prompting.

## Agile board tracking
Closes DSEGOG-466