### PR TITLE
DSEGOG-472 Change how no channel summary error is displayed

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,25 @@ export const paths = {
   adminUsers: '/admin/users',
 };
 
+declare module '@tanstack/react-query' {
+  interface Register {
+    queryMeta: {
+      silentError?: boolean | ((error: AxiosError) => boolean);
+    };
+  }
+}
+
+export const queryCacheConfig: ConstructorParameters<typeof QueryCache>[0] = {
+  onError: (error, query) => {
+    const silentError = query.options.meta?.silentError;
+    const shouldSilenceError =
+      typeof silentError === 'function'
+        ? silentError(error as AxiosError)
+        : silentError;
+    handleOG_APIError(error as AxiosError, !shouldSilenceError);
+  },
+};
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -49,12 +68,7 @@ const queryClient = new QueryClient({
     },
   },
 
-  queryCache: new QueryCache({
-    onError: (error, query) => {
-      const silentError = query.options.meta?.silentError;
-      handleOG_APIError(error as AxiosError, !silentError);
-    },
-  }),
+  queryCache: new QueryCache(queryCacheConfig),
 });
 
 function mapPreloaderStateToProps(state: RootState): { loading: boolean } {

--- a/src/api/channels.test.tsx
+++ b/src/api/channels.test.tsx
@@ -7,12 +7,15 @@ import {
 import { server } from '../mocks/server';
 
 import { http, HttpResponse } from 'msw';
+import { MockInstance } from 'vitest';
+import handleOG_APIError from '../handleOG_APIError';
 import { RootState } from '../state/store';
 import {
   getInitialState,
   hooksWrapperWithProviders,
   testChannels,
 } from '../testUtils';
+import { ogApi } from './api';
 import {
   ChannelSummary,
   getScalarChannels,
@@ -22,6 +25,8 @@ import {
   useChannelSummary,
   useScalarChannels,
 } from './channels';
+
+vi.mock('../handleOG_APIError');
 
 describe('channels api functions', () => {
   afterEach(() => {
@@ -314,6 +319,12 @@ describe('channels api functions', () => {
   });
 
   describe('useChannelSummary', () => {
+    let axiosGetSpy: MockInstance;
+
+    beforeEach(() => {
+      axiosGetSpy = vi.spyOn(ogApi, 'get');
+    });
+
     it('sends request to fetch channel summary and returns successful response', async () => {
       const { result } = renderHook(() => useChannelSummary('CHANNEL_ABCDE'), {
         wrapper: hooksWrapperWithProviders(),
@@ -336,7 +347,7 @@ describe('channels api functions', () => {
       expect(result.current.data).toEqual(expected);
     });
 
-    it('does not send request to fetch channel summary when given no channel or system channel', async () => {
+    it('does not send request to fetch channel summary when given no channel or system channel', () => {
       let requestSent = false;
       server.events.on('request:start', () => {
         requestSent = true;
@@ -359,6 +370,52 @@ describe('channels api functions', () => {
       expect(result.current.isFetching).toBeFalsy();
       expect(result.current.isPending).toBeTruthy();
       expect(requestSent).toBe(false);
+    });
+
+    it('does not retry request when we get a 400 error', async () => {
+      server.use(
+        http.get('/channels/summary/:channelName', () =>
+          HttpResponse.json(
+            {
+              detail: `There is no timestamp data for CHANNEL_ABCDE`,
+            },
+            { status: 400 }
+          )
+        )
+      );
+      const { result } = renderHook(() => useChannelSummary('CHANNEL_ABCDE'), {
+        wrapper: hooksWrapperWithProviders(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBeTruthy();
+      });
+
+      expect(axiosGetSpy).toHaveBeenCalledTimes(1);
+      expect(handleOG_APIError).toHaveBeenCalledWith(expect.any(Error), false);
+    });
+
+    it('retries normally for other errors', async () => {
+      server.use(
+        http.get('/channels/summary/:channelName', () =>
+          HttpResponse.json(
+            {
+              detail: '500 error',
+            },
+            { status: 500 }
+          )
+        )
+      );
+      const { result } = renderHook(() => useChannelSummary('CHANNEL_ABCDE'), {
+        wrapper: hooksWrapperWithProviders(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBeTruthy();
+      });
+
+      expect(axiosGetSpy).toHaveBeenCalledTimes(4);
+      expect(handleOG_APIError).toHaveBeenCalledWith(expect.any(Error), true);
     });
   });
 

--- a/src/api/channels.tsx
+++ b/src/api/channels.tsx
@@ -19,6 +19,7 @@ import {
   ValidateFunctionState,
   type ChannelMetadata,
 } from '../app.types';
+import retryOG_APIErrors from '../retryOG_APIErrors';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
 import { selectAppliedFunctions } from '../state/slices/functionsSlice';
 import {
@@ -87,9 +88,7 @@ export interface ChannelSummary {
   recent_sample: { [timestamp: string]: string | number }[];
 }
 
-const fetchChannelSummary = async (
-  channel: string
-): Promise<ChannelSummary> => {
+const fetchChannelSummary = (channel: string): Promise<ChannelSummary> => {
   return ogApi
     .get(`/channels/summary/${channel}`)
     .then((response) => response.data);
@@ -126,7 +125,15 @@ export const useChannelSummary = (
     queryFn: () => {
       return fetchChannelSummary(dataChannel);
     },
-
+    // 400 error means no data for that channel, so no summary can be generated
+    // so bail out of retries and don't broadcast error message
+    retry: (failureCount, error) => {
+      if (error.response?.status === 400) return false;
+      return retryOG_APIErrors(failureCount, error as AxiosError);
+    },
+    meta: {
+      silentError: (error: AxiosError) => error.response?.status === 400,
+    },
     enabled: dataChannel.length !== 0,
   });
 };

--- a/src/api/records.test.tsx
+++ b/src/api/records.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { parseISO } from 'date-fns';
+import { http, HttpResponse } from 'msw';
 import {
   PlotDataset,
   Record,
@@ -9,7 +10,9 @@ import {
   timeChannelName,
 } from '../app.types';
 import { operators, parseFilter, Token } from '../filtering/filterParser';
+import handleOG_APIError from '../handleOG_APIError';
 import recordsJson from '../mocks/records.json';
+import { server } from '../mocks/server';
 import { MAX_SHOTS_VALUES } from '../search/components/maxShots.component';
 import { RootState } from '../state/store';
 import {
@@ -28,6 +31,8 @@ import {
   useShotnumToDateConverter,
   useThumbnails,
 } from './records';
+
+vi.mock('../handleOG_APIError');
 
 describe('records api functions', () => {
   let state: RootState;
@@ -250,6 +255,34 @@ describe('records api functions', () => {
       expect(result.current.data).toEqual(undefined);
       expect(result.current.isPending).toBe(true);
       expect(result.current.fetchStatus).toBe('idle');
+    });
+
+    it('does not broadcast errors', async () => {
+      server.use(
+        http.get('/records/range_converter', () =>
+          HttpResponse.json(
+            {
+              detail: 'No results have been found from database query',
+            },
+            { status: 500 }
+          )
+        )
+      );
+      const { result } = renderHook(
+        () =>
+          useDateToShotnumConverter(
+            '2026-02-27T00:00:00',
+            '2026-02-27T12:00:00'
+          ),
+        {
+          wrapper: hooksWrapperWithProviders(state),
+        }
+      );
+
+      await waitFor(() => {
+        expect(result.current.isError).toBeTruthy();
+      });
+      expect(handleOG_APIError).toHaveBeenCalledWith(expect.any(Error), false);
     });
   });
 

--- a/src/channels/channelMetadataPanel.component.test.tsx
+++ b/src/channels/channelMetadataPanel.component.test.tsx
@@ -1,8 +1,10 @@
 import { QueryClient } from '@tanstack/react-query';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
 import { staticChannels } from '../api/channels';
 import { FullChannelMetadata } from '../app.types';
+import { server } from '../mocks/server';
 import { RootState } from '../state/store';
 import { renderComponentWithProviders } from '../testUtils';
 import ChannelMetadataPanel from './channelMetadataPanel.component';
@@ -104,6 +106,32 @@ describe('Channel Metadata Panel', () => {
     await user.click(screen.getByRole('button', { name: 'Add this channel' }));
 
     expect(onSelectChannel).toHaveBeenCalledWith(displayedChannel?.systemName);
+  });
+
+  it('should render "no data" message when channel summary endpoint errors with 400', async () => {
+    displayedChannel = {
+      name: 'Channel_ABCDE',
+      systemName: 'CHANNEL_ABCDE',
+      type: 'scalar',
+      units: 'cm',
+      path: '/test',
+      description: 'Test description',
+    };
+    server.use(
+      http.get('/channels/summary/:channelName', () =>
+        HttpResponse.json(
+          {
+            detail: `There is no timestamp data for ${displayedChannel?.systemName}`,
+          },
+          { status: 400 }
+        )
+      )
+    );
+    createView();
+
+    expect(
+      await screen.findByText('No data has been recorded for this channel')
+    ).toBeVisible();
   });
 
   it('should remove displayed channel when it is selected and when remove channel button is clicked', async () => {

--- a/src/channels/channelMetadataPanel.component.tsx
+++ b/src/channels/channelMetadataPanel.component.tsx
@@ -65,9 +65,8 @@ const ChannelMetadataPanel = (props: ChannelMetadataPanelProps) => {
     onDeselectChannel,
   } = props;
 
-  const { data: channelSummary } = useChannelSummary(
-    displayedChannel?.systemName
-  );
+  const { data: channelSummary, error: channelSummaryError } =
+    useChannelSummary(displayedChannel?.systemName);
 
   function addCurrentChannel() {
     if (displayedChannel?.systemName) {
@@ -161,6 +160,19 @@ const ChannelMetadataPanel = (props: ChannelMetadataPanelProps) => {
         )}
         {displayedChannel?.historical && (
           <Body fontWeight="bold">This channel is historical</Body>
+        )}
+        {channelSummaryError?.response?.status === 400 && (
+          <>
+            <Divider />
+            <Typography
+              variant="body2"
+              component="h4"
+              gutterBottom
+              sx={{ paddingTop: 1 }}
+            >
+              No data has been recorded for this channel
+            </Typography>
+          </>
         )}
         {channelSummary && (
           <>

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -1,5 +1,9 @@
 import { Action, ThunkAction } from '@reduxjs/toolkit';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  QueryCache,
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query';
 import type { RenderOptions } from '@testing-library/react';
 import { render } from '@testing-library/react';
 import { matchRequestUrl } from 'msw';
@@ -11,6 +15,7 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import { Provider } from 'react-redux';
 import { staticChannels } from './api/channels';
+import { queryCacheConfig } from './App';
 import {
   DEFAULT_WINDOW_VARS,
   FullChannelMetadata,
@@ -149,9 +154,11 @@ export const createTestQueryClient = (): QueryClient =>
     defaultOptions: {
       queries: {
         retry: false,
+        retryDelay: 1,
         staleTime: 300000,
       },
     },
+    queryCache: new QueryCache(queryCacheConfig),
   });
 
 export const hooksWrapperWithProviders = (


### PR DESCRIPTION
## Description
Surpress the broadcasting of no channel summary error and instead display in the channel summary window like Stephen described in DSEGOG-472.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Probably have to mock the error as now all channels on prod have data

## Agile board tracking
Closes DSEGOG-472
