### PR TITLE
Improve docker build workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,8 +1,11 @@
 name: Release Build
 on:
   push:
+    branches:
+      - develop
     tags:
-    - "*"
+      - '*'
+  workflow_dispatch:
 
 jobs:
   docker:
@@ -12,6 +15,9 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Login to Harbor
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -34,3 +40,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          cache-from: type=gha,scope=prod
+          cache-to: type=gha,scope=prod,mode=max


### PR DESCRIPTION
## Description
Copy the DataGateway/SciGateway docker build workflow so add caching & build images for the develop branch to allow for easier deployment of pre-releases and allow arbitary builds to be manually triggered to allow specific branches to have images automatically published for testing.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

