### PR TITLE
DSEGOG-530 DSEGOG-528 data types

### DIFF
--- a/cypress/e2e/channels.cy.ts
+++ b/cypress/e2e/channels.cy.ts
@@ -13,6 +13,35 @@ describe('Data Channels Component', () => {
     cy.get('[role="dialog"]').should('not.exist');
   });
 
+  it('displays active_area as Data Type when in data types mode', () => {
+    let settings = {};
+    cy.request('operationsgateway-settings.json').then((response) => {
+      settings = response.body;
+    });
+
+    cy.intercept('operationsgateway-settings.json', (req) => {
+      req.reply({
+        statusCode: 200,
+        body: {
+          ...settings,
+          dataTypes: ['GS', 'GA', 'GQ', 'GD'],
+        },
+      });
+    }).as('getSettings');
+
+    cy.reload();
+
+    cy.contains('Data Channels').click();
+
+    cy.contains('system').click();
+
+    cy.findByRole('checkbox', { name: 'Data Type' }).check();
+
+    cy.contains('Add Channels').click();
+
+    cy.findByRole('columnheader', { name: 'Data Type' }).should('be.visible');
+  });
+
   it('lets a user add new channels', () => {
     cy.contains('Data Channels').click();
 

--- a/cypress/e2e/search.cy.ts
+++ b/cypress/e2e/search.cy.ts
@@ -949,7 +949,7 @@ describe('Search', () => {
       cy.findByLabelText('date-time search box').should(
         'have.css',
         'border-color',
-        'rgb(211, 47, 47)' // shade of red
+        'rgb(214, 65, 65)' // shade of red
       );
       cy.findByRole('button', { name: 'Search' }).should(
         'have.attr',
@@ -965,7 +965,7 @@ describe('Search', () => {
       cy.findByLabelText('date-time search box').should(
         'have.css',
         'border-color',
-        'rgb(211, 47, 47)' // shade of red
+        'rgb(214, 65, 65)' // shade of red
       );
       cy.findByRole('button', { name: 'Search' }).should(
         'have.attr',
@@ -981,7 +981,7 @@ describe('Search', () => {
       cy.findByLabelText('date-time search box').should(
         'have.css',
         'border-color',
-        'rgb(211, 47, 47)' // shade of red
+        'rgb(214, 65, 65)' // shade of red
       );
       cy.findByRole('button', { name: 'Search' }).should(
         'have.attr',
@@ -997,7 +997,7 @@ describe('Search', () => {
       cy.findByLabelText('open shot number search box').should(
         'have.css',
         'border-color',
-        'rgb(211, 47, 47)' // shade of red
+        'rgb(214, 65, 65)' // shade of red
       );
       cy.findByRole('button', { name: 'Search' }).should(
         'have.attr',
@@ -1014,7 +1014,7 @@ describe('Search', () => {
       cy.findByLabelText('open shot number search box').should(
         'have.css',
         'border-color',
-        'rgb(211, 47, 47)' // shade of red
+        'rgb(214, 65, 65)' // shade of red
       );
       cy.findByRole('button', { name: 'Search' }).should(
         'have.attr',
@@ -1031,7 +1031,7 @@ describe('Search', () => {
       cy.findByLabelText('open shot number search box').should(
         'have.css',
         'border-color',
-        'rgb(211, 47, 47)' // shade of red
+        'rgb(214, 65, 65)' // shade of red
       );
       cy.findByRole('button', { name: 'Search' }).should(
         'have.attr',

--- a/cypress/e2e/search.cy.ts
+++ b/cypress/e2e/search.cy.ts
@@ -949,7 +949,7 @@ describe('Search', () => {
       cy.findByLabelText('date-time search box').should(
         'have.css',
         'border-color',
-        'rgb(214, 65, 65)' // shade of red
+        'rgb(211, 47, 47)' // shade of red
       );
       cy.findByRole('button', { name: 'Search' }).should(
         'have.attr',
@@ -965,7 +965,7 @@ describe('Search', () => {
       cy.findByLabelText('date-time search box').should(
         'have.css',
         'border-color',
-        'rgb(214, 65, 65)' // shade of red
+        'rgb(211, 47, 47)' // shade of red
       );
       cy.findByRole('button', { name: 'Search' }).should(
         'have.attr',
@@ -981,7 +981,7 @@ describe('Search', () => {
       cy.findByLabelText('date-time search box').should(
         'have.css',
         'border-color',
-        'rgb(214, 65, 65)' // shade of red
+        'rgb(211, 47, 47)' // shade of red
       );
       cy.findByRole('button', { name: 'Search' }).should(
         'have.attr',
@@ -997,7 +997,7 @@ describe('Search', () => {
       cy.findByLabelText('open shot number search box').should(
         'have.css',
         'border-color',
-        'rgb(214, 65, 65)' // shade of red
+        'rgb(211, 47, 47)' // shade of red
       );
       cy.findByRole('button', { name: 'Search' }).should(
         'have.attr',
@@ -1014,7 +1014,7 @@ describe('Search', () => {
       cy.findByLabelText('open shot number search box').should(
         'have.css',
         'border-color',
-        'rgb(214, 65, 65)' // shade of red
+        'rgb(211, 47, 47)' // shade of red
       );
       cy.findByRole('button', { name: 'Search' }).should(
         'have.attr',
@@ -1031,7 +1031,7 @@ describe('Search', () => {
       cy.findByLabelText('open shot number search box').should(
         'have.css',
         'border-color',
-        'rgb(214, 65, 65)' // shade of red
+        'rgb(211, 47, 47)' // shade of red
       );
       cy.findByRole('button', { name: 'Search' }).should(
         'have.attr',

--- a/cypress/e2e/search.cy.ts
+++ b/cypress/e2e/search.cy.ts
@@ -12,9 +12,9 @@ function getConditionsFromParams(params: Map<string, string>) {
 
 describe('Search', () => {
   describe('no record limits', () => {
+    // We need no limit set on the records to ensure we don't get warning tooltips for these tests to pass
+    let settings = Object.create(null);
     beforeEach(() => {
-      // We need no limit set on the records to ensure we don't get warning tooltips for these tests to pass
-      let settings = Object.create(null);
       cy.request('operationsgateway-settings.json').then((response) => {
         settings = response.body;
       });
@@ -46,7 +46,8 @@ describe('Search', () => {
 
       cy.findByRole('button', { name: 'Search' }).click();
 
-      // wait for search to finish
+      // wait for search to initiate and finish
+      cy.findByRole('progressbar').should('exist');
       cy.findByRole('progressbar').should('not.exist');
 
       cy.findBrowserMockedRequests({ method: 'GET', url: '/records' }).should(
@@ -118,7 +119,8 @@ describe('Search', () => {
 
         cy.findByRole('button', { name: 'Search' }).click();
 
-        // wait for search to finish
+        // wait for search to initiate and finish
+        cy.findByRole('progressbar').should('exist');
         cy.findByRole('progressbar').should('not.exist');
 
         cy.findBrowserMockedRequests({ method: 'GET', url: '/records' }).should(
@@ -183,7 +185,8 @@ describe('Search', () => {
 
         cy.findByRole('button', { name: 'Search' }).click();
 
-        // wait for search to finish
+        // wait for search to initiate and finish
+        cy.findByRole('progressbar').should('exist');
         cy.findByRole('progressbar').should('not.exist');
 
         cy.findBrowserMockedRequests({ method: 'GET', url: '/records' }).should(
@@ -248,7 +251,8 @@ describe('Search', () => {
 
         cy.findByRole('button', { name: 'Search' }).click();
 
-        // wait for search to finish
+        // wait for search to initiate and finish
+        cy.findByRole('progressbar').should('exist');
         cy.findByRole('progressbar').should('not.exist');
 
         cy.findBrowserMockedRequests({ method: 'GET', url: '/records' }).should(
@@ -337,7 +341,7 @@ describe('Search', () => {
 
         cy.findByRole('button', { name: 'Search' }).click();
 
-        // wait for search to finish
+        // wait for search to initiate and finish
         cy.findByRole('progressbar').should('exist');
         cy.findByRole('progressbar').should('not.exist');
 
@@ -370,7 +374,7 @@ describe('Search', () => {
 
         cy.findByLabelText('Refresh data').click();
 
-        // wait for search to finish
+        // wait for search to initiate and finish
         cy.findByRole('progressbar').should('exist');
         cy.findByRole('progressbar').should('not.exist');
 
@@ -444,7 +448,7 @@ describe('Search', () => {
 
         cy.findByRole('button', { name: 'Search' }).click();
 
-        // wait for search to finish
+        // wait for search to initiate and finish
         cy.findByRole('progressbar').should('exist');
         cy.findByRole('progressbar').should('not.exist');
 
@@ -477,7 +481,7 @@ describe('Search', () => {
 
         cy.findByLabelText('Refresh data').click();
 
-        // wait for search to finish
+        // wait for search to initiate and finish
         cy.findByRole('progressbar', { timeout: 15_000 }).should('exist');
         cy.findByRole('progressbar').should('not.exist');
 
@@ -545,7 +549,8 @@ describe('Search', () => {
 
         cy.findByRole('button', { name: 'Search' }).click();
 
-        // wait for search to finish
+        // wait for search to initiate and finish
+        cy.findByRole('progressbar').should('exist');
         cy.findByRole('progressbar').should('not.exist');
 
         cy.findBrowserMockedRequests({ method: 'GET', url: '/records' }).should(
@@ -611,7 +616,8 @@ describe('Search', () => {
 
         cy.findByRole('button', { name: 'Search' }).click();
 
-        // wait for search to finish
+        // wait for search to initiate and finish
+        cy.findByRole('progressbar').should('exist');
         cy.findByRole('progressbar').should('not.exist');
 
         cy.findBrowserMockedRequests({ method: 'GET', url: '/records' }).should(
@@ -677,7 +683,8 @@ describe('Search', () => {
 
         cy.findByRole('button', { name: 'Search' }).click();
 
-        // wait for search to finish
+        // wait for search to initiate and finish
+        cy.findByRole('progressbar').should('exist');
         cy.findByRole('progressbar').should('not.exist');
 
         cy.findBrowserMockedRequests({ method: 'GET', url: '/records' }).should(
@@ -736,7 +743,8 @@ describe('Search', () => {
 
       cy.findByRole('button', { name: 'Search' }).click();
 
-      // wait for search to finish
+      // wait for search to initiate and finish
+      cy.findByRole('progressbar').should('exist');
       cy.findByRole('progressbar').should('not.exist');
 
       cy.findBrowserMockedRequests({ method: 'GET', url: '/records' }).should(
@@ -783,6 +791,153 @@ describe('Search', () => {
       });
     });
 
+    it('searches by shot number range in data types mode', () => {
+      cy.intercept('operationsgateway-settings.json', (req) => {
+        req.reply({
+          statusCode: 200,
+          body: {
+            ...settings,
+            recordLimitWarning: -1,
+            dataTypes: ['GS', 'GA', 'GQ', 'GD'],
+          },
+        });
+      }).as('getSettings');
+
+      cy.reload();
+      cy.findByRole('tabpanel', { name: 'Data' }).should('be.visible');
+      cy.findByRole('progressbar').should('not.exist');
+
+      // expect all data types to be selected initially
+      cy.findByRole('checkbox', { name: 'GA' }).should('be.checked');
+      cy.findByRole('checkbox', { name: 'GD' }).should('be.checked');
+      cy.findByRole('checkbox', { name: 'GQ' }).should('be.checked');
+      cy.findByRole('checkbox', { name: 'GS' }).should('be.checked');
+
+      cy.findByLabelText('open shot number search box').click();
+      cy.findByRole('tooltip', {
+        name: 'Please ensure a single data type is selected to enable searching by shot number',
+      });
+      cy.findByText('Select your shot number').should('not.exist');
+
+      // uncheck all checkboxes except one
+      cy.findByRole('checkbox', { name: 'GA' }).click();
+      cy.findByRole('checkbox', { name: 'GD' }).click();
+      cy.findByRole('checkbox', { name: 'GQ' }).click();
+
+      cy.findByLabelText('open shot number search box').click();
+      cy.findByRole('tooltip', {
+        name: 'Please ensure a single data type is selected to enable searching by shot number',
+      }).should('not.exist');
+
+      cy.findByRole('textbox', { name: 'Min' }).type('1');
+      cy.findByRole('textbox', { name: 'Max' }).type('9');
+
+      cy.startSnoopingBrowserMockedRequest();
+
+      cy.findByRole('button', { name: 'Search' }).click();
+
+      // wait for search to initiate and finish
+      cy.findByRole('progressbar').should('exist');
+      cy.findByRole('progressbar').should('not.exist');
+
+      cy.findBrowserMockedRequests({ method: 'GET', url: '/records' }).should(
+        (patchRequests) => {
+          expect(patchRequests.length).equal(1);
+          const request = patchRequests[0];
+
+          expect(request.url.toString()).to.contain('conditions=');
+          const paramMap: Map<string, string> = getParamsFromUrl(
+            request.url.toString()
+          );
+          const conditionsMap = getConditionsFromParams(paramMap);
+
+          expect(conditionsMap.length).equal(2);
+
+          const timestampCondition = conditionsMap[0];
+          const timestampRange = timestampCondition['metadata.timestamp'];
+          const timestampGte: string = timestampRange['$gte'];
+          const timestampLte: string = timestampRange['$lte'];
+          expect(timestampGte).equal('2022-01-01T00:00:00');
+          expect(timestampLte).equal('2022-01-09T00:00:59');
+
+          const dataTypeCondition = conditionsMap[1];
+          expect(
+            dataTypeCondition['metadata.active_area']['$in']
+          ).to.deep.equal(['GS']);
+        }
+      );
+
+      cy.findBrowserMockedRequests({
+        method: 'GET',
+        url: '/records/count',
+      }).should((patchRequests) => {
+        expect(patchRequests.length).equal(1);
+        const request = patchRequests[0];
+
+        expect(request.url.toString()).to.contain('conditions=');
+        const paramMap: Map<string, string> = getParamsFromUrl(
+          request.url.toString()
+        );
+        const conditionsMap = getConditionsFromParams(paramMap);
+        expect(conditionsMap.length).equal(2);
+
+        const timestampCondition = conditionsMap[0];
+        const timestampRange = timestampCondition['metadata.timestamp'];
+        const timestampGte: string = timestampRange['$gte'];
+        const timestampLte: string = timestampRange['$lte'];
+        expect(timestampGte).equal('2022-01-01T00:00:00');
+        expect(timestampLte).equal('2022-01-09T00:00:59');
+
+        const dataTypeCondition = conditionsMap[1];
+        expect(dataTypeCondition['metadata.active_area']['$in']).to.deep.equal([
+          'GS',
+        ]);
+      });
+    });
+
+    it('converts date times to shot num ranges in data type mode', () => {
+      cy.intercept('operationsgateway-settings.json', (req) => {
+        req.reply({
+          statusCode: 200,
+          body: {
+            ...settings,
+            recordLimitWarning: -1,
+            dataTypes: ['GS', 'GA', 'GQ', 'GD'],
+          },
+        });
+      }).as('getSettings');
+
+      cy.reload();
+      cy.findByRole('tabpanel', { name: 'Data' }).should('be.visible');
+      cy.findByRole('progressbar').should('not.exist');
+
+      cy.findByLabelText('from, date-time input').type('2022-01-01 00:00');
+      cy.findByLabelText('to, date-time input').type('2022-01-02 00:00');
+
+      // expect all data types to be selected initially
+      cy.findByRole('checkbox', { name: 'GA' }).should('be.checked');
+      cy.findByRole('checkbox', { name: 'GD' }).should('be.checked');
+      cy.findByRole('checkbox', { name: 'GQ' }).should('be.checked');
+      cy.findByRole('checkbox', { name: 'GS' }).should('be.checked');
+
+      cy.findByText('Shot Number')
+        .parent()
+        .findByText('Select')
+        .should('be.visible');
+      cy.findByText('Shot Number').should(
+        'have.css',
+        'color',
+        'rgba(0, 0, 0, 0.26)' // shade of grey
+      );
+
+      // uncheck all checkboxes except one
+      cy.findByRole('checkbox', { name: 'GA' }).click();
+      cy.findByRole('checkbox', { name: 'GD' }).click();
+      cy.findByRole('checkbox', { name: 'GQ' }).click();
+
+      cy.findByText('1 to 2').should('be.visible');
+    });
+
     it('should highlight boxes red if error in search params', () => {
       // Date-time box
 
@@ -794,7 +949,7 @@ describe('Search', () => {
       cy.findByLabelText('date-time search box').should(
         'have.css',
         'border-color',
-        'rgb(214, 65, 65)' // shade of red
+        'rgb(211, 47, 47)' // shade of red
       );
       cy.findByRole('button', { name: 'Search' }).should(
         'have.attr',
@@ -810,7 +965,7 @@ describe('Search', () => {
       cy.findByLabelText('date-time search box').should(
         'have.css',
         'border-color',
-        'rgb(214, 65, 65)' // shade of red
+        'rgb(211, 47, 47)' // shade of red
       );
       cy.findByRole('button', { name: 'Search' }).should(
         'have.attr',
@@ -826,7 +981,7 @@ describe('Search', () => {
       cy.findByLabelText('date-time search box').should(
         'have.css',
         'border-color',
-        'rgb(214, 65, 65)' // shade of red
+        'rgb(211, 47, 47)' // shade of red
       );
       cy.findByRole('button', { name: 'Search' }).should(
         'have.attr',
@@ -842,7 +997,7 @@ describe('Search', () => {
       cy.findByLabelText('open shot number search box').should(
         'have.css',
         'border-color',
-        'rgb(214, 65, 65)' // shade of red
+        'rgb(211, 47, 47)' // shade of red
       );
       cy.findByRole('button', { name: 'Search' }).should(
         'have.attr',
@@ -859,7 +1014,7 @@ describe('Search', () => {
       cy.findByLabelText('open shot number search box').should(
         'have.css',
         'border-color',
-        'rgb(214, 65, 65)' // shade of red
+        'rgb(211, 47, 47)' // shade of red
       );
       cy.findByRole('button', { name: 'Search' }).should(
         'have.attr',
@@ -876,7 +1031,7 @@ describe('Search', () => {
       cy.findByLabelText('open shot number search box').should(
         'have.css',
         'border-color',
-        'rgb(214, 65, 65)' // shade of red
+        'rgb(211, 47, 47)' // shade of red
       );
       cy.findByRole('button', { name: 'Search' }).should(
         'have.attr',
@@ -944,7 +1099,8 @@ describe('Search', () => {
 
       cy.findByRole('button', { name: 'Search' }).click();
 
-      // wait for search to finish
+      // wait for search to initiate and finish
+      cy.findByRole('progressbar').should('exist');
       cy.findByRole('progressbar').should('not.exist');
 
       cy.findBrowserMockedRequests({ method: 'GET', url: '/records' }).should(
@@ -1006,7 +1162,8 @@ describe('Search', () => {
 
       cy.findByRole('button', { name: 'Search' }).click();
 
-      // wait for search to finish
+      // wait for search to initiate and finish
+      cy.findByRole('progressbar').should('exist');
       cy.findByRole('progressbar').should('not.exist');
 
       cy.findBrowserMockedRequests({ method: 'GET', url: '/records' }).should(
@@ -1326,6 +1483,11 @@ describe('Search', () => {
       cy.findByLabelText('from, date-time input').type('2022-01-11_00:00');
 
       cy.findByRole('button', { name: 'Search' }).click();
+
+      // wait for search to initiate and finish
+      cy.findByRole('progressbar').should('exist');
+      cy.findByRole('progressbar').should('not.exist');
+
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(100);
       cy.findByRole('button', { name: 'Search' }).trigger('mouseover');

--- a/e2e/real/search.spec.ts
+++ b/e2e/real/search.spec.ts
@@ -56,7 +56,7 @@ test('should be able to search via data type', async ({ page }) => {
   await page.route('/operationsgateway-settings.json', async (route) => {
     const response = await route.fetch();
     const json = await response.json();
-    json.dataTypes = ['ea1', 'ea2'];
+    json.dataTypes = ['ea1', 'las'];
     // Fulfill using the original response, while patching the response body
     // with the given JSON object.
     await route.fulfill({ response, json });
@@ -65,8 +65,8 @@ test('should be able to search via data type', async ({ page }) => {
   await page.goto('/');
 
   // test searching across multiple data types
-  await page.getByLabel('from, date-time input').fill('2023-06-21 10:55');
-  await page.getByLabel('to, date-time input').fill('2023-06-21 12:05');
+  await page.getByLabel('from, date-time input').fill('2023-06-05 09:55');
+  await page.getByLabel('to, date-time input').fill('2023-06-05 10:05');
 
   await page.getByRole('button', { name: 'Search', exact: true }).click();
 
@@ -84,13 +84,13 @@ test('should be able to search via data type', async ({ page }) => {
   await page.getByRole('button', { name: 'Add Channels' }).click();
 
   await expect(page.getByRole('rowgroup').last().getByRole('row')).toHaveCount(
-    11
+    7
   );
   await expect(page.getByRole('cell', { name: 'ea1' }).first()).toBeVisible();
-  await expect(page.getByRole('cell', { name: 'ea2' }).first()).toBeVisible();
+  await expect(page.getByRole('cell', { name: 'las' }).first()).toBeVisible();
 
   // test searching by a specific data type
-  await page.getByRole('checkbox', { name: 'ea2' }).uncheck();
+  await page.getByRole('checkbox', { name: 'las' }).uncheck();
 
   await page.getByRole('button', { name: 'Search', exact: true }).click();
 
@@ -98,7 +98,7 @@ test('should be able to search via data type', async ({ page }) => {
     5
   );
   await expect(page.getByRole('cell', { name: 'ea1' }).first()).toBeVisible();
-  await expect(page.getByRole('cell', { name: 'ea2' })).not.toBeVisible();
+  await expect(page.getByRole('cell', { name: 'las' })).not.toBeVisible();
 });
 
 // skip testing timeframes as 1) it would be complicated and

--- a/e2e/real/search.spec.ts
+++ b/e2e/real/search.spec.ts
@@ -52,6 +52,54 @@ test('should be able to search experiment id', async ({ page }) => {
   await expect(page.getByText('1–25 of 50')).toBeVisible();
 });
 
-// skip testing explicitly setting the date time, as we do that in a lot of other tests
-// also skip testing timeframes as 1) it would be complicated and
+test('should be able to search via data type', async ({ page }) => {
+  await page.route('/operationsgateway-settings.json', async (route) => {
+    const response = await route.fetch();
+    const json = await response.json();
+    json.dataTypes = ['ea1', 'ea2'];
+    // Fulfill using the original response, while patching the response body
+    // with the given JSON object.
+    await route.fulfill({ response, json });
+  });
+
+  await page.goto('/');
+
+  // test searching across multiple data types
+  await page.getByLabel('from, date-time input').fill('2023-06-21 10:55');
+  await page.getByLabel('to, date-time input').fill('2023-06-21 12:05');
+
+  await page.getByRole('button', { name: 'Search', exact: true }).click();
+
+  await page.getByRole('button', { name: 'Data channels' }).click();
+
+  await page
+    .getByRole('combobox', { name: 'Search data channels' })
+    .fill('Data Type');
+
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('Enter');
+
+  await page.getByRole('button', { name: 'Add this channel' }).click();
+
+  await page.getByRole('button', { name: 'Add Channels' }).click();
+
+  await expect(page.getByRole('rowgroup').last().getByRole('row')).toHaveCount(
+    11
+  );
+  await expect(page.getByRole('cell', { name: 'ea1' }).first()).toBeVisible();
+  await expect(page.getByRole('cell', { name: 'ea2' }).first()).toBeVisible();
+
+  // test searching by a specific data type
+  await page.getByRole('checkbox', { name: 'ea2' }).uncheck();
+
+  await page.getByRole('button', { name: 'Search', exact: true }).click();
+
+  await expect(page.getByRole('rowgroup').last().getByRole('row')).toHaveCount(
+    5
+  );
+  await expect(page.getByRole('cell', { name: 'ea1' }).first()).toBeVisible();
+  await expect(page.getByRole('cell', { name: 'ea2' })).not.toBeVisible();
+});
+
+// skip testing timeframes as 1) it would be complicated and
 // 2) all it does in our code is convert it to timestamps so no need to test against real API

--- a/e2e/real/search.spec.ts
+++ b/e2e/real/search.spec.ts
@@ -53,10 +53,15 @@ test('should be able to search experiment id', async ({ page }) => {
 });
 
 test('should be able to search via data type', async ({ page }) => {
+  test.skip(
+    process.env.CI !== 'true',
+    'This test will only pass against CI data'
+  );
+
   await page.route('/operationsgateway-settings.json', async (route) => {
     const response = await route.fetch();
     const json = await response.json();
-    json.dataTypes = ['ea1', 'las'];
+    json.dataTypes = ['ea1', 'ea2'];
     // Fulfill using the original response, while patching the response body
     // with the given JSON object.
     await route.fulfill({ response, json });
@@ -65,8 +70,8 @@ test('should be able to search via data type', async ({ page }) => {
   await page.goto('/');
 
   // test searching across multiple data types
-  await page.getByLabel('from, date-time input').fill('2023-06-05 09:55');
-  await page.getByLabel('to, date-time input').fill('2023-06-05 10:05');
+  await page.getByLabel('from, date-time input').fill('2023-06-05 09:00');
+  await page.getByLabel('to, date-time input').fill('2023-06-05 17:00');
 
   await page.getByRole('button', { name: 'Search', exact: true }).click();
 
@@ -84,21 +89,21 @@ test('should be able to search via data type', async ({ page }) => {
   await page.getByRole('button', { name: 'Add Channels' }).click();
 
   await expect(page.getByRole('rowgroup').last().getByRole('row')).toHaveCount(
-    7
+    4
   );
   await expect(page.getByRole('cell', { name: 'ea1' }).first()).toBeVisible();
-  await expect(page.getByRole('cell', { name: 'las' }).first()).toBeVisible();
+  await expect(page.getByRole('cell', { name: 'ea2' }).first()).toBeVisible();
 
   // test searching by a specific data type
-  await page.getByRole('checkbox', { name: 'las' }).uncheck();
+  await page.getByRole('checkbox', { name: 'ea2' }).uncheck();
 
   await page.getByRole('button', { name: 'Search', exact: true }).click();
 
   await expect(page.getByRole('rowgroup').last().getByRole('row')).toHaveCount(
-    5
+    3
   );
   await expect(page.getByRole('cell', { name: 'ea1' }).first()).toBeVisible();
-  await expect(page.getByRole('cell', { name: 'las' })).not.toBeVisible();
+  await expect(page.getByRole('cell', { name: 'ea2' })).not.toBeVisible();
 });
 
 // skip testing timeframes as 1) it would be complicated and

--- a/public/operationsgateway-settings.example.json
+++ b/public/operationsgateway-settings.example.json
@@ -2,6 +2,7 @@
   "apiUrl": "",
   "recordLimitWarning": -1,
   "workingHours": { "start": 9, "end": 18 },
+  "dataTypes": [],
   "plotAxisSigFigs": ".3~s",
   "routes": [
     {

--- a/src/api/records.test.tsx
+++ b/src/api/records.test.tsx
@@ -77,6 +77,7 @@ describe('records api functions', () => {
               toDate: '2022-01-02 00:00:00',
             },
             maxShots: MAX_SHOTS_VALUES[0],
+            dataTypes: ['GS', 'GQ'],
           },
         },
         filter: {
@@ -105,7 +106,7 @@ describe('records api functions', () => {
 
       params.append(
         'conditions',
-        '{"$and":[{"metadata.timestamp":{"$gte":"2022-01-01 00:00:00","$lte":"2022-01-02 00:00:00"}},{"metadata.shotnum":{"$gt":300}}]}'
+        '{"$and":[{"metadata.timestamp":{"$gte":"2022-01-01 00:00:00","$lte":"2022-01-02 00:00:00"}},{"metadata.active_area":{"$in":["GS","GQ"]}},{"metadata.shotnum":{"$gt":300}}]}'
       );
 
       expect(new URL(request.url).searchParams.toString()).toEqual(
@@ -187,7 +188,7 @@ describe('records api functions', () => {
   });
 
   describe('useShotnumToDateConverter', () => {
-    it('send a request to fetch date using ShotnumToDateConverter and returns a succesful response', async () => {
+    it('send a request to fetch date using ShotnumToDateConverter and returns a successful response', async () => {
       const expectedReponse = {
         from: '2022-01-04T00:00:00',
         to: '2022-01-18T00:00:00',
@@ -208,9 +209,36 @@ describe('records api functions', () => {
 
       expect(result.current.data).toEqual(expectedReponse);
     });
+
+    it('send a request to fetch date using ShotnumToDateConverter with a data type and returns a successful response', async () => {
+      const expectedReponse = {
+        from: '2022-01-05T00:00:00',
+        to: '2022-01-17T00:00:00',
+        min: 4,
+        max: 19,
+      };
+
+      const { result } = renderHook(
+        () =>
+          useShotnumToDateConverter(
+            expectedReponse.min,
+            expectedReponse.max,
+            'TEST'
+          ),
+        {
+          wrapper: hooksWrapperWithProviders(state),
+        }
+      );
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBeTruthy();
+      });
+
+      expect(result.current.data).toEqual(expectedReponse);
+    });
+
     it('does not send a request to fetch date using ShotnumToDateConverter when query set to disabled', async () => {
       const { result } = renderHook(
-        () => useShotnumToDateConverter(undefined, undefined, false),
+        () => useShotnumToDateConverter(undefined, undefined, undefined, false),
         {
           wrapper: hooksWrapperWithProviders(state),
         }
@@ -223,7 +251,7 @@ describe('records api functions', () => {
   });
 
   describe('useDateToShotnumConverter', () => {
-    it('send a request to fetch date usingDateToShotnumConverter and returns a succesful response', async () => {
+    it('send a request to fetch date usingDateToShotnumConverter and returns a successful response', async () => {
       const expectedReponse = {
         from: '2021-12-01T00:00:00',
         to: '2022-01-19T00:00:00',
@@ -244,9 +272,36 @@ describe('records api functions', () => {
 
       expect(result.current.data).toEqual(expectedReponse);
     });
+
+    it('send a request to fetch date usingDateToShotnumConverter a data type and returns a successful response', async () => {
+      const expectedReponse = {
+        from: '2021-12-01T00:00:00',
+        to: '2022-01-19T00:00:00',
+        min: 1,
+        max: 17,
+      };
+
+      const { result } = renderHook(
+        () =>
+          useDateToShotnumConverter(
+            expectedReponse.from,
+            expectedReponse.to,
+            'TEST'
+          ),
+        {
+          wrapper: hooksWrapperWithProviders(state),
+        }
+      );
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBeTruthy();
+      });
+
+      expect(result.current.data).toEqual(expectedReponse);
+    });
+
     it('does not send a request to fetch date usingDateToShotnumConverter when query set to disabled', async () => {
       const { result } = renderHook(
-        () => useDateToShotnumConverter(undefined, undefined, false),
+        () => useDateToShotnumConverter(undefined, undefined, undefined, false),
         {
           wrapper: hooksWrapperWithProviders(state),
         }
@@ -474,6 +529,7 @@ describe('records api functions', () => {
               toDate: '2022-01-02 00:00:00',
             },
             maxShots: MAX_SHOTS_VALUES[0],
+            dataTypes: ['GA'],
           },
         },
         filter: {
@@ -521,7 +577,7 @@ describe('records api functions', () => {
       );
       params.append(
         'conditions',
-        '{"$and":[{"metadata.timestamp":{"$gte":"2022-01-01 00:00:00","$lte":"2022-01-02 00:00:00"}},{"metadata.shotnum":{"$gt":300}}],"$or":[{"channels.CHANNEL_1":{"$exists":true}},{"channels.CHANNEL_2":{"$exists":true}}]}'
+        '{"$and":[{"metadata.timestamp":{"$gte":"2022-01-01 00:00:00","$lte":"2022-01-02 00:00:00"}},{"metadata.active_area":{"$in":["GA"]}},{"metadata.shotnum":{"$gt":300}}],"$or":[{"channels.CHANNEL_1":{"$exists":true}},{"channels.CHANNEL_2":{"$exists":true}}]}'
       );
       params.append('skip', '0');
       params.append('limit', '25');

--- a/src/api/records.tsx
+++ b/src/api/records.tsx
@@ -17,6 +17,7 @@ import {
   RecordRow,
   SearchParams,
   SelectedPlotChannel,
+  ShotNumType,
   SortType,
   timeChannelName,
 } from '../app.types';
@@ -53,7 +54,7 @@ const fetchRecords = async (
     queryParams.append('order', `${sortKey} ${value}`);
   }
 
-  const { dateRange } = searchParams;
+  const { dateRange, dataTypes } = searchParams;
 
   let timestampObj = {};
   if (dateRange.fromDate || dateRange.toDate) {
@@ -71,6 +72,7 @@ const fetchRecords = async (
 
   const searchObj = [];
   if (dateRange.fromDate || dateRange.toDate) searchObj.push(timestampObj);
+  if (dataTypes) searchObj.push({ 'metadata.active_area': { $in: dataTypes } });
 
   searchObj.push(...filtersObj);
 
@@ -160,7 +162,7 @@ const fetchRecordCountQuery = async (
 ): Promise<number> => {
   const queryParams = new URLSearchParams();
 
-  const { dateRange } = searchParams;
+  const { dateRange, dataTypes } = searchParams;
 
   let timestampObj = {};
   if (dateRange.fromDate || dateRange.toDate) {
@@ -178,6 +180,7 @@ const fetchRecordCountQuery = async (
 
   const searchObj = [];
   if (dateRange.fromDate || dateRange.toDate) searchObj.push(timestampObj);
+  if (dataTypes) searchObj.push({ 'metadata.active_area': { $in: dataTypes } });
 
   searchObj.push(...filtersObj);
 
@@ -224,29 +227,33 @@ const fetchRecordCountQuery = async (
 export const fetchRangeRecordConverterQuery = async (
   fromDate: string | undefined,
   toDate: string | undefined,
-  shotnumMin: number | undefined,
-  shotnumMax: number | undefined
+  shotnumMin: ShotNumType | undefined,
+  shotnumMax: ShotNumType | undefined,
+  dataType?: string
 ): Promise<DateRangetoShotnumConverter> => {
   const queryParams = new URLSearchParams();
-  let timestampObj = {};
+  let timestampObj: { from?: string; to?: string; type?: string } = {};
   if (fromDate || toDate) {
     timestampObj = {
       from: fromDate,
       to: toDate,
     };
   }
+  if (dataType) timestampObj.type = dataType;
 
   if (fromDate || toDate) {
     queryParams.append('date_range', JSON.stringify(timestampObj));
   }
 
-  let shotnumObj = {};
+  let shotnumObj: { min?: ShotNumType; max?: ShotNumType; type?: string } = {};
   if (shotnumMin || shotnumMax) {
     shotnumObj = {
       min: shotnumMin,
       max: shotnumMax,
     };
   }
+
+  if (dataType) shotnumObj.type = dataType;
 
   if (shotnumMin || shotnumMax) {
     queryParams.append('shotnum_range', JSON.stringify(shotnumObj));
@@ -271,17 +278,19 @@ export const fetchRangeRecordConverterQuery = async (
 export const useDateToShotnumConverter = (
   fromDate: string | undefined,
   toDate: string | undefined,
+  dataType?: string,
   enabled?: boolean
 ): UseQueryResult<DateRangetoShotnumConverter, AxiosError> => {
   return useQuery({
-    queryKey: ['dateToShotnumConverter', { fromDate, toDate }],
+    queryKey: ['dateToShotnumConverter', { fromDate, toDate, dataType }],
 
     queryFn: () => {
       return fetchRangeRecordConverterQuery(
         fromDate,
         toDate,
         undefined,
-        undefined
+        undefined,
+        dataType
       );
     },
     meta: {
@@ -292,18 +301,20 @@ export const useDateToShotnumConverter = (
 };
 
 export const useShotnumToDateConverter = (
-  shotnumMin: number | undefined,
-  shotnumMax: number | undefined,
+  shotnumMin: ShotNumType | undefined,
+  shotnumMax: ShotNumType | undefined,
+  dataType?: string,
   enabled?: boolean
 ): UseQueryResult<DateRangetoShotnumConverter, AxiosError> => {
   return useQuery({
-    queryKey: ['shotnumToDateConverter', { shotnumMin, shotnumMax }],
+    queryKey: ['shotnumToDateConverter', { shotnumMin, shotnumMax, dataType }],
     queryFn: () =>
       fetchRangeRecordConverterQuery(
         undefined,
         undefined,
         shotnumMin,
-        shotnumMax
+        shotnumMax,
+        dataType
       ),
     enabled,
   });
@@ -412,7 +423,10 @@ export const getFormattedAxisData = (
       ).getTime();
       break;
     case 'shotnum':
-      formattedData = record.metadata.shotnum ?? NaN;
+      formattedData =
+        typeof record.metadata.shotnum === 'number'
+          ? record.metadata.shotnum
+          : NaN;
       break;
     case 'active_area':
       formattedData = record.metadata.active_area

--- a/src/app.types.tsx
+++ b/src/app.types.tsx
@@ -24,11 +24,13 @@ export interface Record {
   channels?: { [channel: string]: Channel | undefined };
 }
 
+export type ShotNumType = number | string;
+
 export interface RecordRow {
   _id: string;
   timestamp: string;
   active_area: string;
-  shotnum?: number;
+  shotnum?: ShotNumType;
   active_experiment?: string;
   channelMetadata: { [channel: string]: ChannelMetadata };
   [channel: string]: unknown;
@@ -74,7 +76,7 @@ export interface RecordMetadata {
   epac_ops_data_version: string;
   timestamp: string;
   active_area: string;
-  shotnum?: number;
+  shotnum?: ShotNumType;
   active_experiment?: string;
 }
 
@@ -225,13 +227,13 @@ export interface DateRange {
 export interface DateRangetoShotnumConverter {
   from?: string;
   to?: string;
-  min?: number;
-  max?: number;
+  min?: ShotNumType;
+  max?: ShotNumType;
 }
 
 export interface ShotnumRange {
-  min?: number;
-  max?: number;
+  min?: ShotNumType;
+  max?: ShotNumType;
 }
 
 export interface ExperimentParams {
@@ -247,6 +249,7 @@ export interface SearchParams {
   shotnumRange: ShotnumRange;
   maxShots: number;
   experimentID: ExperimentParams | null;
+  dataTypes?: string[];
 }
 
 export interface ColumnState {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -165,14 +165,15 @@ export const handlers = [
     const dateRange = url.searchParams.get('date_range');
 
     if (shotnumRange) {
-      const { min, max } = JSON.parse(decodeURIComponent(shotnumRange));
+      const { min, max, type } = JSON.parse(decodeURIComponent(shotnumRange));
       const shotnumMin = Number(min);
       const shotnumMax = Number(max);
 
-      const shotnumRangeRecord = recordsJson.filter((record) => {
+      const shotnumRangeRecord = recordsJson.filter((record, index) => {
         return (
           record.metadata.shotnum >= shotnumMin &&
-          record.metadata.shotnum <= shotnumMax
+          record.metadata.shotnum <= shotnumMax &&
+          (type === 'TEST' ? index % 2 === 0 : true) // simulate filtering out some records that don't "match" the type
         );
       });
 
@@ -201,14 +202,17 @@ export const handlers = [
 
       return HttpResponse.json(responseData, { status: 200 });
     } else if (dateRange) {
-      const { from: fromDate, to: toDate } = JSON.parse(
-        decodeURIComponent(dateRange)
-      );
+      const {
+        from: fromDate,
+        to: toDate,
+        type,
+      } = JSON.parse(decodeURIComponent(dateRange));
 
-      const dateRangeRecord = recordsJson.filter((record) => {
+      const dateRangeRecord = recordsJson.filter((record, index) => {
         return (
           new Date(record.metadata.timestamp) >= new Date(fromDate) &&
-          new Date(record.metadata.timestamp) <= new Date(toDate)
+          new Date(record.metadata.timestamp) <= new Date(toDate) &&
+          (type === 'TEST' ? index % 2 === 0 : true) // simulate filtering out some records that don't "match" the type
         );
       });
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -200,7 +200,13 @@ export const handlers = [
         to: shotnumMaxRecord?.metadata?.timestamp,
       };
 
-      return HttpResponse.json(responseData, { status: 200 });
+      if (responseData.from && responseData.to)
+        return HttpResponse.json(responseData, { status: 200 });
+      else
+        return HttpResponse.json(
+          { detail: 'No results have been found from database query' },
+          { status: 500 }
+        );
     } else if (dateRange) {
       const {
         from: fromDate,
@@ -241,7 +247,13 @@ export const handlers = [
         min: fromDateRecord?.metadata?.shotnum,
         max: toDateRecord?.metadata?.shotnum,
       };
-      return HttpResponse.json(responseData, { status: 200 });
+      if (responseData.min && responseData.max)
+        return HttpResponse.json(responseData, { status: 200 });
+      else
+        return HttpResponse.json(
+          { detail: 'No results have been found from database query' },
+          { status: 500 }
+        );
     } else {
       return HttpResponse.json(undefined, { status: 500 });
     }

--- a/src/search/components/__snapshots__/dataTypes.component.test.tsx.snap
+++ b/src/search/components/__snapshots__/dataTypes.component.test.tsx.snap
@@ -1,0 +1,148 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`data types selector > renders correctly with a list of data types with some selected and some not selected 1`] = `
+<DocumentFragment>
+  <fieldset
+    aria-label="select data types to display"
+    class="MuiFormControl-root css-1wnvimt-MuiFormControl-root"
+  >
+    <div
+      class="MuiBox-root css-u4p24i"
+    >
+      <legend
+        class="MuiFormLabel-root MuiFormLabel-colorPrimary Mui-required css-noxuvf-MuiFormLabel-root"
+      >
+        Data Types
+        <span
+          aria-hidden="true"
+          class="MuiFormLabel-asterisk css-1ljffdk-MuiFormLabel-asterisk"
+        >
+           *
+        </span>
+      </legend>
+      <div
+        class="MuiFormGroup-root MuiFormGroup-row css-cis11t-MuiFormGroup-root"
+      >
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-is1gm-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+          >
+            <input
+              checked=""
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
+              data-indeterminate="false"
+              type="checkbox"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+              data-testid="CheckBoxIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+              />
+            </svg>
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
+          >
+            GS
+          </span>
+        </label>
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-is1gm-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+          >
+            <input
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
+              data-indeterminate="false"
+              type="checkbox"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+              data-testid="CheckBoxOutlineBlankIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
+          >
+            GD
+          </span>
+        </label>
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-checked MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-is1gm-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+          >
+            <input
+              checked=""
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
+              data-indeterminate="false"
+              type="checkbox"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+              data-testid="CheckBoxIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+              />
+            </svg>
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
+          >
+            GA
+          </span>
+        </label>
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
+        >
+          <span
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-is1gm-MuiButtonBase-root-MuiSwitchBase-root-MuiCheckbox-root"
+          >
+            <input
+              class="PrivateSwitchBase-input css-12xagqm-MuiSwitchBase-root"
+              data-indeterminate="false"
+              type="checkbox"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+              data-testid="CheckBoxOutlineBlankIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+          </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-rizt0-MuiTypography-root"
+          >
+            GQ
+          </span>
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</DocumentFragment>
+`;

--- a/src/search/components/__snapshots__/shotNumber.component.test.tsx.snap
+++ b/src/search/components/__snapshots__/shotNumber.component.test.tsx.snap
@@ -1,5 +1,45 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`shotNumber search > "disables" when noSingleDataTypeSelected is true 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-79elbk"
+  >
+    <div
+      aria-label="open shot number search box"
+      class="MuiBox-root css-rp81um"
+      data-mui-internal-clone-element="true"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1onip98-MuiSvgIcon-root"
+        data-testid="AdjustIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.49 2 2 6.49 2 12s4.49 10 10 10 10-4.49 10-10S17.51 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8m3-8c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3"
+        />
+      </svg>
+      <div
+        class="MuiBox-root css-1xgbetl"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-cq7yze-MuiTypography-root"
+        >
+          Shot Number
+        </p>
+        <h6
+          class="MuiTypography-root MuiTypography-subtitle1 css-1i3tsf3-MuiTypography-root"
+        >
+          Select
+        </h6>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`shotNumber search > renders correctly 1`] = `
 <DocumentFragment>
   <div
@@ -8,6 +48,7 @@ exports[`shotNumber search > renders correctly 1`] = `
     <div
       aria-label="close shot number search box"
       class="MuiBox-root css-bm8stw"
+      data-mui-internal-clone-element="true"
     >
       <svg
         aria-hidden="true"
@@ -20,7 +61,9 @@ exports[`shotNumber search > renders correctly 1`] = `
           d="M12 2C6.49 2 2 6.49 2 12s4.49 10 10 10 10-4.49 10-10S17.51 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8m3-8c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3"
         />
       </svg>
-      <div>
+      <div
+        class="MuiBox-root css-0"
+      >
         <p
           class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-cq7yze-MuiTypography-root"
         >
@@ -60,8 +103,8 @@ exports[`shotNumber search > renders correctly 1`] = `
               <label
                 class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1kfabtt-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="false"
-                for=":r0:"
-                id=":r0:-label"
+                for=":r1:"
+                id=":r1:-label"
               >
                 Min
               </label>
@@ -71,7 +114,7 @@ exports[`shotNumber search > renders correctly 1`] = `
                 <input
                   aria-invalid="false"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1pzfmz2-MuiInputBase-input-MuiOutlinedInput-input"
-                  id=":r0:"
+                  id=":r1:"
                   min="0"
                   name="shot number min"
                   type="number"
@@ -110,8 +153,8 @@ exports[`shotNumber search > renders correctly 1`] = `
               <label
                 class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeSmall MuiInputLabel-outlined css-1kfabtt-MuiFormLabel-root-MuiInputLabel-root"
                 data-shrink="false"
-                for=":r1:"
-                id=":r1:-label"
+                for=":r2:"
+                id=":r2:-label"
               >
                 Max
               </label>
@@ -121,7 +164,7 @@ exports[`shotNumber search > renders correctly 1`] = `
                 <input
                   aria-invalid="false"
                   class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1pzfmz2-MuiInputBase-input-MuiOutlinedInput-input"
-                  id=":r1:"
+                  id=":r2:"
                   min="0"
                   name="shot number max"
                   type="number"

--- a/src/search/components/dataTypes.component.test.tsx
+++ b/src/search/components/dataTypes.component.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, type RenderResult } from '@testing-library/react';
+import userEvent, { UserEvent } from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { initialState as initialConfigState } from '../../state/slices/configSlice';
+import { RootState, setupStore } from '../../state/store';
+import DataTypes, { type DataTypesProps } from './dataTypes.component';
+
+describe('data types selector', () => {
+  let user: UserEvent;
+  let props: DataTypesProps;
+  const changeSelectedDataTypes = vi.fn();
+  const searchParamsUpdated = vi.fn();
+  let state: Partial<RootState>;
+
+  const createView = (): RenderResult => {
+    return render(<DataTypes {...props} />, {
+      wrapper: ({ children }) => (
+        <Provider store={setupStore(state)}>{children}</Provider>
+      ),
+    });
+  };
+
+  beforeEach(() => {
+    user = userEvent.setup();
+    state = {
+      config: { ...initialConfigState, dataTypes: ['GS', 'GD', 'GA', 'GQ'] },
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders correctly with a list of data types with some selected and some not selected', () => {
+    props = {
+      selectedDataTypes: ['GS', 'GA'],
+      changeSelectedDataTypes,
+      searchParamsUpdated,
+    };
+
+    const { asFragment } = createView();
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('calls changeDataTypes when user clicks', async () => {
+    props = {
+      selectedDataTypes: ['GA'],
+      changeSelectedDataTypes,
+      searchParamsUpdated,
+    };
+    createView();
+
+    await user.click(screen.getByRole('checkbox', { name: 'GS' }));
+    expect(changeSelectedDataTypes).toHaveBeenCalledWith(expect.any(Function));
+    expect(searchParamsUpdated).toHaveBeenCalled();
+  });
+
+  it('renders error when no types selected', async () => {
+    props = {
+      selectedDataTypes: [],
+      changeSelectedDataTypes,
+      searchParamsUpdated,
+    };
+    createView();
+
+    expect(screen.getByText('Please select a data type')).toBeInTheDocument();
+  });
+});

--- a/src/search/components/dataTypes.component.tsx
+++ b/src/search/components/dataTypes.component.tsx
@@ -1,0 +1,74 @@
+import {
+  Box,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+  FormHelperText,
+  FormLabel,
+} from '@mui/material';
+import React from 'react';
+import { SearchParams } from '../../app.types';
+import { useAppSelector } from '../../state/hooks';
+import { selectDataTypes } from '../../state/slices/configSlice';
+
+export interface DataTypesProps {
+  selectedDataTypes: NonNullable<SearchParams['dataTypes']>;
+  changeSelectedDataTypes: React.Dispatch<
+    React.SetStateAction<SearchParams['dataTypes']>
+  >;
+  searchParamsUpdated: () => void;
+}
+
+const DataTypes = (props: DataTypesProps): React.ReactElement => {
+  const { selectedDataTypes, changeSelectedDataTypes, searchParamsUpdated } =
+    props;
+
+  const dataTypes = useAppSelector(selectDataTypes);
+
+  return (
+    <FormControl
+      aria-label="select data types to display"
+      component="fieldset"
+      required
+      variant="standard"
+      error={selectedDataTypes.length === 0}
+      sx={{ position: 'relative', mt: 1 }}
+    >
+      <Box display="flex" flexDirection="row" alignItems="center">
+        <FormLabel component="legend" sx={{ float: 'left', mr: 2 }}>
+          Data Types
+        </FormLabel>
+        <FormGroup row>
+          {dataTypes?.map((dataType) => (
+            <FormControlLabel
+              key={dataType}
+              control={
+                <Checkbox
+                  checked={selectedDataTypes.includes(dataType)}
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    searchParamsUpdated();
+                    changeSelectedDataTypes((prevDataTypes) => {
+                      if (event.target.checked)
+                        return prevDataTypes?.concat(dataType);
+                      else return prevDataTypes?.filter((s) => s !== dataType);
+                    });
+                  }}
+                  sx={{ p: 0 }}
+                />
+              }
+              label={dataType}
+            />
+          ))}
+        </FormGroup>
+      </Box>
+      {selectedDataTypes.length === 0 && (
+        <FormHelperText sx={{ mt: 0 }}>
+          Please select a data type
+        </FormHelperText>
+      )}
+    </FormControl>
+  );
+};
+
+export default DataTypes;

--- a/src/search/components/dateTime.component.tsx
+++ b/src/search/components/dateTime.component.tsx
@@ -272,7 +272,7 @@ const DateTimeSearch = (props: DateTimeSearchProps): React.ReactElement => {
         border: '1.5px solid',
         borderColor:
           datePickerFromDateError || datePickerToDateError || invalidDateRange
-            ? 'rgb(214, 65, 65)'
+            ? 'error.main'
             : undefined,
         borderRadius: '10px',
         display: 'flex',

--- a/src/search/components/shotNumber.component.test.tsx
+++ b/src/search/components/shotNumber.component.test.tsx
@@ -29,6 +29,7 @@ describe('shotNumber search', () => {
       isDateToShotnum: false,
       invalidShotNumberRange: false,
       searchParamsUpdated: searchParamsUpdated,
+      shotNumType: 'number',
     };
 
     user = userEvent.setup();
@@ -41,6 +42,19 @@ describe('shotNumber search', () => {
   it('renders correctly', async () => {
     const { asFragment } = createView();
     await user.click(screen.getByLabelText('open shot number search box'));
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('"disables" when noSingleDataTypeSelected is true', async () => {
+    props.shotNumType = 'string';
+    props.noSingleDataTypeSelected = true;
+    const { asFragment } = createView();
+    await user.click(screen.getByLabelText('open shot number search box'));
+    expect(
+      await screen.findByRole('tooltip', {
+        name: 'Please ensure a single data type is selected to enable searching by shot number',
+      })
+    ).toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
   });
 
@@ -75,6 +89,31 @@ describe('shotNumber search', () => {
     await user.type(maxInput, '2');
     expect(changeSearchParameterShotnumMin).toHaveBeenCalledWith(1);
     expect(changeSearchParameterShotnumMax).toHaveBeenCalledWith(2);
+    expect(resetDateRange).toHaveBeenCalled();
+    expect(searchParamsUpdated).toHaveBeenCalled();
+    const helperTexts = within(shotnumPopup).queryAllByText('Invalid range');
+    expect(helperTexts.length).toEqual(0);
+  });
+
+  it('allows user to change min and max values for string shot numbers', async () => {
+    props.shotNumType = 'string';
+    createView();
+
+    await user.click(screen.getByLabelText('open shot number search box'));
+    const shotnumPopup = screen.getByRole('dialog');
+    const minInput = within(shotnumPopup).getByRole('textbox', {
+      name: 'Min',
+    });
+    const maxInput = within(shotnumPopup).getByRole('textbox', {
+      name: 'Max',
+    });
+
+    await user.click(minInput);
+    await user.paste('GA-1');
+    await user.click(maxInput);
+    await user.paste('GA-2');
+    expect(changeSearchParameterShotnumMin).toHaveBeenCalledWith('GA-1');
+    expect(changeSearchParameterShotnumMax).toHaveBeenCalledWith('GA-2');
     expect(resetDateRange).toHaveBeenCalled();
     expect(searchParamsUpdated).toHaveBeenCalled();
     const helperTexts = within(shotnumPopup).queryAllByText('Invalid range');

--- a/src/search/components/shotNumber.component.tsx
+++ b/src/search/components/shotNumber.component.tsx
@@ -4,22 +4,26 @@ import {
   Divider,
   Grid2 as Grid,
   TextField,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import React from 'react';
 import { FLASH_ANIMATION } from '../../animation';
+import { ShotNumType } from '../../app.types';
 import { useClickOutside } from '../../hooks';
 
 export interface ShotNumberProps {
-  searchParameterShotnumMin?: number;
-  searchParameterShotnumMax?: number;
-  changeSearchParameterShotnumMin: (min: number | undefined) => void;
-  changeSearchParameterShotnumMax: (max: number | undefined) => void;
+  searchParameterShotnumMin?: ShotNumType;
+  searchParameterShotnumMax?: ShotNumType;
+  changeSearchParameterShotnumMin: (min: ShotNumType | undefined) => void;
+  changeSearchParameterShotnumMax: (max: ShotNumType | undefined) => void;
   resetDateRange: () => void;
   resetExperimentTimeframe: () => void;
   isDateToShotnum: boolean;
   invalidShotNumberRange: boolean;
   searchParamsUpdated: () => void;
+  noSingleDataTypeSelected?: boolean;
+  shotNumType: 'number' | 'string';
 }
 
 const ShotNumberPopup = (props: ShotNumberProps): React.ReactElement => {
@@ -32,6 +36,7 @@ const ShotNumberPopup = (props: ShotNumberProps): React.ReactElement => {
     resetDateRange,
     resetExperimentTimeframe,
     searchParamsUpdated,
+    shotNumType,
   } = props;
 
   return (
@@ -58,12 +63,16 @@ const ShotNumberPopup = (props: ShotNumberProps): React.ReactElement => {
             name="shot number min"
             label="Min"
             value={min ?? ''}
-            type="number"
+            type={shotNumType === 'number' ? 'number' : 'text'}
             size="small"
             slotProps={{ htmlInput: { min: 0 } }}
             onChange={(event) => {
               changeMin(
-                event.target.value ? Number(event.target.value) : undefined
+                event.target.value
+                  ? shotNumType === 'number'
+                    ? Number(event.target.value)
+                    : event.target.value
+                  : undefined
               );
               resetDateRange();
               searchParamsUpdated();
@@ -81,12 +90,16 @@ const ShotNumberPopup = (props: ShotNumberProps): React.ReactElement => {
             name="shot number max"
             label="Max"
             value={max ?? ''}
-            type="number"
+            type={shotNumType === 'number' ? 'number' : 'text'}
             size="small"
             slotProps={{ htmlInput: { min: 0 } }}
             onChange={(event) => {
               changeMax(
-                event.target.value ? Number(event.target.value) : undefined
+                event.target.value
+                  ? shotNumType === 'number'
+                    ? Number(event.target.value)
+                    : event.target.value
+                  : undefined
               );
               resetDateRange();
               searchParamsUpdated();
@@ -107,6 +120,7 @@ const ShotNumber = (props: ShotNumberProps): React.ReactElement => {
     searchParameterShotnumMax: max,
     isDateToShotnum,
     invalidShotNumberRange,
+    noSingleDataTypeSelected,
   } = props;
 
   const popover = React.useRef<HTMLDivElement | null>(null);
@@ -145,40 +159,65 @@ const ShotNumber = (props: ShotNumberProps): React.ReactElement => {
 
   return (
     <Box sx={{ position: 'relative' }} ref={parent}>
-      <Box
-        aria-label={`${isOpen ? 'close' : 'open'} shot number search box`}
-        sx={{
-          border: '1.5px solid',
-          borderColor: invalidShotNumberRange ? 'rgb(214, 65, 65)' : undefined,
-          borderRadius: '10px',
-          display: 'flex',
-          flexDirection: 'row',
-          paddingRight: 2,
-          paddingBottom: '4px',
-          cursor: 'pointer',
-          overflow: 'hidden',
-          ...(flashAnimationPlaying && {
-            animation: `${FLASH_ANIMATION.animation} ${FLASH_ANIMATION.length}ms`,
-          }),
-        }}
-        onClick={() => toggle(!isOpen)}
+      <Tooltip
+        title={
+          noSingleDataTypeSelected
+            ? 'Please ensure a single data type is selected to enable searching by shot number'
+            : null
+        }
       >
-        <Adjust sx={{ fontSize: 32, margin: '0px 2px', alignSelf: 'center' }} />
-        <div>
-          <Typography noWrap sx={{ fontWeight: 'bold' }}>
-            Shot Number
-          </Typography>
-          <Typography variant="subtitle1">
-            {min !== undefined && max === undefined
-              ? `Minimum: ${min}`
-              : min === undefined && max !== undefined
-                ? `Maximum: ${max}`
-                : min !== undefined && max !== undefined
-                  ? `${min} to ${max}`
-                  : 'Select'}
-          </Typography>
-        </div>
-      </Box>
+        <Box
+          aria-label={`${isOpen ? 'close' : 'open'} shot number search box`}
+          sx={{
+            border: '1.5px solid',
+            borderColor: invalidShotNumberRange
+              ? 'error.main'
+              : noSingleDataTypeSelected
+                ? 'action.disabled'
+                : undefined,
+            borderRadius: '10px',
+            display: 'flex',
+            flexDirection: 'row',
+            paddingRight: 2,
+            paddingBottom: '4px',
+            cursor: !noSingleDataTypeSelected ? 'pointer' : 'default',
+            overflow: 'hidden',
+            ...(flashAnimationPlaying && {
+              animation: `${FLASH_ANIMATION.animation} ${FLASH_ANIMATION.length}ms`,
+            }),
+          }}
+          onClick={() => {
+            if (!noSingleDataTypeSelected) toggle(!isOpen);
+          }}
+        >
+          <Adjust
+            sx={{
+              fontSize: 32,
+              margin: '0px 2px',
+              alignSelf: 'center',
+              color: noSingleDataTypeSelected ? 'action.disabled' : undefined,
+            }}
+          />
+          <Box
+            sx={{
+              color: noSingleDataTypeSelected ? 'action.disabled' : undefined,
+            }}
+          >
+            <Typography noWrap sx={{ fontWeight: 'bold' }}>
+              Shot Number
+            </Typography>
+            <Typography variant="subtitle1">
+              {min !== undefined && max === undefined
+                ? `Minimum: ${min}`
+                : min === undefined && max !== undefined
+                  ? `Maximum: ${max}`
+                  : min !== undefined && max !== undefined
+                    ? `${min} to ${max}`
+                    : 'Select'}
+            </Typography>
+          </Box>
+        </Box>
+      </Tooltip>
       {isOpen && (
         <Box
           role="dialog"

--- a/src/search/searchBar.component.test.tsx
+++ b/src/search/searchBar.component.test.tsx
@@ -82,6 +82,7 @@ describe('searchBar component', () => {
 
     await user.click(screen.getByRole('button', { name: 'Search' }));
     expect(store.getState().search.searchParams).toStrictEqual({
+      dataTypes: undefined,
       dateRange: {
         fromDate: '2022-01-01T00:00:00',
         toDate: '2022-01-02T00:00:59',
@@ -135,6 +136,7 @@ describe('searchBar component', () => {
 
     await user.click(screen.getByRole('button', { name: 'Search' }));
     expect(store.getState().search.searchParams).toStrictEqual({
+      dataTypes: undefined,
       dateRange: {
         fromDate: '2022-01-05T00:00:00',
         toDate: '2022-01-10T00:00:59',
@@ -185,6 +187,7 @@ describe('searchBar component', () => {
 
     await user.click(screen.getByRole('button', { name: 'Search' }));
     expect(store.getState().search.searchParams).toStrictEqual({
+      dataTypes: undefined,
       dateRange: {
         fromDate: '2022-01-12T00:00:00',
         toDate: '2022-01-15T00:00:59',
@@ -235,6 +238,7 @@ describe('searchBar component', () => {
 
     await user.click(screen.getByRole('button', { name: 'Search' }));
     expect(store.getState().search.searchParams).toStrictEqual({
+      dataTypes: undefined,
       dateRange: {
         fromDate: '2022-01-13T00:00:00',
         toDate: '2022-01-16T00:00:59',
@@ -269,6 +273,7 @@ describe('searchBar component', () => {
 
     await user.click(screen.getByRole('button', { name: 'Search' }));
     expect(store.getState().search.searchParams).toStrictEqual({
+      dataTypes: undefined,
       dateRange: {
         fromDate: expectedExperiment.start_date,
         toDate: expectedEndDate,
@@ -297,6 +302,7 @@ describe('searchBar component', () => {
 
     await user.click(screen.getByRole('button', { name: 'Search' }));
     expect(store.getState().search.searchParams).toStrictEqual({
+      dataTypes: undefined,
       dateRange: {
         fromDate: '2022-01-01T00:00:00',
         toDate: '2022-01-02T00:00:59',
@@ -323,6 +329,7 @@ describe('searchBar component', () => {
     await user.click(screen.getByRole('button', { name: 'Search' }));
 
     expect(store.getState().search.searchParams).toStrictEqual({
+      dataTypes: undefined,
       dateRange: {
         fromDate: '2024-07-01T12:00:00',
         toDate: '2024-07-02T12:00:59',
@@ -475,6 +482,7 @@ describe('searchBar component', () => {
 
     // Store should not be updated, indicating search is yet to initiate
     expect(store.getState().search.searchParams).toStrictEqual({
+      dataTypes: undefined,
       dateRange: {},
       experimentID: null,
       shotnumRange: {},
@@ -486,6 +494,7 @@ describe('searchBar component', () => {
 
     // Store should now be updated, indicating search initiated on second attempt
     expect(store.getState().search.searchParams).toStrictEqual({
+      dataTypes: undefined,
       dateRange: {
         fromDate: '2022-01-01T00:00:00',
         toDate: '2023-01-01T00:00:59',
@@ -645,6 +654,7 @@ describe('searchBar component', () => {
 
     // Store should be updated after one click of the search button
     expect(store.getState().search.searchParams).toStrictEqual({
+      dataTypes: undefined,
       dateRange: {
         fromDate: '2022-01-01T00:00:00',
         toDate: '2023-01-01T00:00:59',
@@ -815,6 +825,7 @@ describe('searchBar component', () => {
       // wait for search to complete updating the store
       await waitFor(() =>
         expect(store.getState().search.searchParams).toStrictEqual({
+          dataTypes: undefined,
           dateRange: {
             fromDate: '2022-01-05T00:00:00',
             toDate: '2022-01-16T00:00:59',
@@ -988,5 +999,113 @@ describe('searchBar component', () => {
     const { container } = createView();
 
     expect(container).toBeEmptyDOMElement();
+  });
+
+  describe('data types', () => {
+    let state: RootState;
+    beforeEach(() => {
+      state = {
+        ...getInitialState(),
+        config: {
+          ...getInitialState().config,
+          dataTypes: ['GS', 'GA', 'GD', 'GQ'],
+        },
+        search: {
+          ...getInitialState().search,
+          searchParams: {
+            ...getInitialState().search.searchParams,
+            dataTypes: ['GS', 'GQ'],
+          },
+        },
+      };
+    });
+
+    it('can add & remove selected data types and they get updated in search params', async () => {
+      const { store } = createView(state);
+
+      const gsCheckbox = screen.getByRole('checkbox', { name: 'GS' });
+      expect(gsCheckbox).toBeChecked();
+
+      await user.click(gsCheckbox);
+      expect(gsCheckbox).not.toBeChecked();
+
+      const gaCheckbox = screen.getByRole('checkbox', { name: 'GA' });
+      expect(gaCheckbox).not.toBeChecked();
+
+      await user.click(gaCheckbox);
+      expect(gaCheckbox).toBeChecked();
+
+      await user.click(screen.getByRole('button', { name: 'Search' }));
+      expect(store.getState().search.searchParams).toMatchObject({
+        dataTypes: ['GQ', 'GA'],
+      });
+    });
+
+    it('disables the search button if no data types are selected', async () => {
+      createView(state);
+
+      await user.click(screen.getByRole('checkbox', { name: 'GS' }));
+
+      await user.click(screen.getByRole('checkbox', { name: 'GQ' }));
+
+      expect(screen.getByText('Please select a data type')).toBeInTheDocument();
+
+      const searchButton = screen.getByRole('button', { name: 'Search' });
+      expect(searchButton).toBeDisabled();
+    });
+
+    it('shotnum conversion enabled when 1 data type selected and disabled otherwise', async () => {
+      createView(state);
+
+      const dateFilterFromDate = screen.getByLabelText('from, date-time input');
+      const dateFilterToDate = screen.getByLabelText('to, date-time input');
+
+      await user.type(dateFilterFromDate, '2022-01-01_00:00');
+      await user.type(dateFilterToDate, '2022-01-02_00:00');
+
+      expect(
+        within(screen.getByLabelText('open shot number search box')).getByText(
+          'Select'
+        )
+      ).toBeInTheDocument();
+
+      await user.hover(screen.getByLabelText('open shot number search box'));
+
+      expect(
+        await screen.findByRole('tooltip', {
+          name: 'Please ensure a single data type is selected to enable searching by shot number',
+        })
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole('checkbox', { name: 'GS' }));
+
+      await waitFor(() =>
+        expect(
+          within(
+            screen.getByLabelText('open shot number search box')
+          ).queryByText('Select')
+        ).not.toBeInTheDocument()
+      );
+
+      await user.hover(screen.getByLabelText('open shot number search box'));
+
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('checkbox', { name: 'GQ' }));
+
+      expect(
+        within(screen.getByLabelText('open shot number search box')).getByText(
+          'Select'
+        )
+      ).toBeInTheDocument();
+
+      await user.hover(screen.getByLabelText('open shot number search box'));
+
+      expect(
+        await screen.findByRole('tooltip', {
+          name: 'Please ensure a single data type is selected to enable searching by shot number',
+        })
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/src/search/searchBar.component.test.tsx
+++ b/src/search/searchBar.component.test.tsx
@@ -38,6 +38,7 @@ describe('searchBar component', () => {
       sessionId: '1',
       heightRef: () => {},
     };
+    vi.setSystemTime(new Date('2022-01-03 12:00:00'));
   });
 
   afterEach(() => {
@@ -319,7 +320,7 @@ describe('searchBar component', () => {
   it('sends default search parameters when none are amended by the user', async () => {
     vi.useFakeTimers({
       toFake: ['Date', 'setTimeout', 'clearTimeout'],
-    }).setSystemTime(new Date('2024-07-02 12:00:00'));
+    }).setSystemTime(new Date('2022-01-03 12:00:00'));
 
     user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
 
@@ -331,8 +332,8 @@ describe('searchBar component', () => {
     expect(store.getState().search.searchParams).toStrictEqual({
       dataTypes: undefined,
       dateRange: {
-        fromDate: '2024-07-01T12:00:00',
-        toDate: '2024-07-02T12:00:59',
+        fromDate: '2022-01-02T12:00:00',
+        toDate: '2022-01-03T12:00:59',
       },
       shotnumRange: {},
       maxShots: MAX_SHOTS_VALUES[0],

--- a/src/search/searchBar.component.tsx
+++ b/src/search/searchBar.component.tsx
@@ -22,9 +22,13 @@ import {
   ExperimentParams,
   SearchParams,
   ShotnumRange,
+  ShotNumType,
 } from '../app.types';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
-import { selectRecordLimitWarning } from '../state/slices/configSlice';
+import {
+  selectDataTypes,
+  selectRecordLimitWarning,
+} from '../state/slices/configSlice';
 import { selectQueryFilters } from '../state/slices/filterSlice';
 import {
   changeSearchParams,
@@ -33,6 +37,7 @@ import {
 } from '../state/slices/searchSlice';
 import AutoRefreshToggle from './components/autoRefreshToggle.component';
 import DataRefresh from './components/dataRefresh.component';
+import DataTypes from './components/dataTypes.component';
 import DateTime from './components/dateTime.component';
 import Experiment from './components/experiment.component';
 import MaxShots, { MAX_SHOTS_VALUES } from './components/maxShots.component';
@@ -60,8 +65,14 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
   const { expanded, sessionId, heightRef } = props;
 
   const searchParams = useAppSelector(selectSearchParams); // the parameters sent to the search query itself
-  const { shotnumRange, maxShots: maxShotsParam, experimentID } = searchParams;
+  const {
+    shotnumRange,
+    maxShots: maxShotsParam,
+    experimentID,
+    dataTypes: dataTypesParam,
+  } = searchParams;
   const dateRangeLocalTime = useAppSelector(selectDateRangeInLocalTime);
+  const allDataTypes = useAppSelector(selectDataTypes);
 
   // we need filters so we can check for past queries before showing the warning message
   const filters = useAppSelector(selectQueryFilters);
@@ -138,9 +149,9 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
   // ########################
   // The SHOT NUMBER MIN AND MAX fields sent as part of the query (if any)
   const [searchParameterShotnumMin, setSearchParameterShotnumMin] =
-    React.useState<number | undefined>(shotnumRange.min ?? undefined);
+    React.useState<ShotNumType | undefined>(shotnumRange.min ?? undefined);
   const [searchParameterShotnumMax, setSearchParameterShotnumMax] =
-    React.useState<number | undefined>(shotnumRange.max ?? undefined);
+    React.useState<ShotNumType | undefined>(shotnumRange.max ?? undefined);
 
   const setShotnumberRange = React.useCallback(
     (shotnumMin: number | undefined, shotnumMax: number | undefined) => {
@@ -152,6 +163,9 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
 
   const [maxShots, setMaxShots] =
     React.useState<SearchParams['maxShots']>(maxShotsParam);
+
+  const [dataTypes, setDataTypes] =
+    React.useState<SearchParams['dataTypes']>(dataTypesParam);
 
   // ########################
   // Experiment ID
@@ -228,21 +242,25 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
       searchParameterToDate
         ? formatDateTimeForApi(searchParameterToDate)
         : undefined,
+      dataTypes && dataTypes.length === 1 ? dataTypes?.[0] : undefined,
       // only enable query when dates are not null and the range is valid
       !invalidDateRange &&
-        !(searchParameterFromDate === null && searchParameterToDate === null)
+        !(searchParameterFromDate === null && searchParameterToDate === null) &&
+        (typeof dataTypes === 'undefined' || dataTypes.length === 1)
     );
 
   // Shot number range to date range converter
   const { data: shotnumToDate } = useShotnumToDateConverter(
     searchParameterShotnumMin,
     searchParameterShotnumMax,
+    dataTypes && dataTypes.length === 1 ? dataTypes?.[0] : undefined,
     // only enable query when shot numbers are not undefined and the range is valid
     !invalidShotNumberRange &&
       !(
         typeof searchParameterShotnumMin === 'undefined' &&
         typeof searchParameterShotnumMax === 'undefined'
-      )
+      ) &&
+      (typeof dataTypes === 'undefined' || dataTypes.length === 1)
   );
 
   // Checks for changes to shot number range and date range
@@ -329,8 +347,15 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
     setSearchParameterShotnumMax(shotnumRange.max);
 
     setMaxShots(maxShotsParam);
+    setDataTypes(dataTypesParam);
     setParamsUpdated(false);
-  }, [dateRangeLocalTime, experimentID, maxShotsParam, shotnumRange]);
+  }, [
+    dateRangeLocalTime,
+    experimentID,
+    maxShotsParam,
+    dataTypesParam,
+    shotnumRange,
+  ]);
 
   const firstUpdate = React.useRef(true);
   // use a ref so that we can control the useEffect that's supposed to
@@ -346,9 +371,10 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
       setSearchParameterShotnumMin(undefined);
       setSearchParameterShotnumMax(undefined);
       setMaxShots(MAX_SHOTS_VALUES[0]);
+      setDataTypes(allDataTypes);
       setTimeframeRange(null);
     } else firstUpdate.current = false;
-  }, [sessionId]);
+  }, [allDataTypes, sessionId]);
 
   const searchParamsUpdated = () => {
     setParamsUpdated(true);
@@ -412,6 +438,7 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
       shotnumRange: newShotnumRange,
       maxShots,
       experimentID: searchParameterExperiment,
+      dataTypes,
     };
 
     setIncomingParams(newSearchParams);
@@ -443,8 +470,9 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
     searchParameterToDate,
     searchParameterShotnumMin,
     searchParameterShotnumMax,
-    searchParameterExperiment,
     maxShots,
+    searchParameterExperiment,
+    dataTypes,
     displayingWarningMessage,
     queryClient,
     filters,
@@ -514,6 +542,29 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
     }
   }, [handleSearch, queryClient, refreshingData, timeFrameChangedAfterRefresh]);
 
+  // ensure that we clear shot numbers when multiple data types detected
+  const changeDataTypes: React.Dispatch<
+    React.SetStateAction<SearchParams['dataTypes']>
+  > = React.useCallback(
+    (s) => {
+      setDataTypes(s);
+      if (Array.isArray(s)) {
+        if (s.length !== 1) {
+          setSearchParameterShotnumMin(undefined);
+          setSearchParameterShotnumMax(undefined);
+        }
+      }
+      if (typeof s === 'function') {
+        const newDataTypes = s(dataTypes);
+        if (newDataTypes && newDataTypes.length !== 1) {
+          setSearchParameterShotnumMin(undefined);
+          setSearchParameterShotnumMax(undefined);
+        }
+      }
+    },
+    [dataTypes]
+  );
+
   return (
     <Collapse in={expanded} timeout="auto" unmountOnExit>
       <Grid container spacing={1} direction="row" ref={heightRef}>
@@ -571,6 +622,14 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
                 isDateToShotnum={isDateToShotnum}
                 invalidShotNumberRange={invalidShotNumberRange}
                 searchParamsUpdated={searchParamsUpdated}
+                noSingleDataTypeSelected={
+                  Array.isArray(dataTypes) ? dataTypes.length !== 1 : undefined
+                }
+                shotNumType={
+                  Array.isArray(allDataTypes) && allDataTypes.length > 0
+                    ? 'string'
+                    : 'number'
+                }
               />
             </Grid>
             <Grid size="auto">
@@ -631,7 +690,11 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
                   variant={paramsUpdated ? 'contained' : 'outlined'}
                   sx={{ height: '100%', paddingLeft: 1, paddingRight: 1 }}
                   onClick={handleSearch}
-                  disabled={invalidDateRange || invalidShotNumberRange}
+                  disabled={
+                    invalidDateRange ||
+                    invalidShotNumberRange ||
+                    (typeof dataTypes !== 'undefined' && dataTypes.length === 0)
+                  }
                 >
                   Search
                 </Button>
@@ -639,7 +702,7 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
             </Grid>
           </Grid>
         </Grid>
-        <Grid container direction="row" columnGap={5}>
+        <Grid container direction="row" columnGap={1}>
           <Grid>
             <MaxShots
               maxShots={maxShots}
@@ -647,6 +710,15 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
               searchParamsUpdated={searchParamsUpdated}
             />
           </Grid>
+          {dataTypes && (
+            <Grid>
+              <DataTypes
+                selectedDataTypes={dataTypes}
+                changeSelectedDataTypes={changeDataTypes}
+                searchParamsUpdated={searchParamsUpdated}
+              />
+            </Grid>
+          )}
           <Grid>
             <DataRefresh
               timeframeSet={!!timeframeRange}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -18,6 +18,7 @@ export interface OperationsGatewaySettings {
   pluginHost?: string;
   workingHours?: WorkingHours;
   plotAxisSigFigs?: string;
+  dataTypes?: string[];
 }
 
 export let settings: Promise<OperationsGatewaySettings | void>;

--- a/src/state/slices/configSlice.test.tsx
+++ b/src/state/slices/configSlice.test.tsx
@@ -1,8 +1,10 @@
+import { staticChannels } from '../../api/channels';
 import { setSettings } from '../../settings';
 import { actions, dispatch, resetActions } from '../../testUtils';
 import ConfigReducer, {
   configureApp,
   initialState,
+  loadDataTypesSetting,
   loadPlotAxisSigFigsSetting,
   loadPluginHostSetting,
   loadRecordLimitWarningSetting,
@@ -10,10 +12,19 @@ import ConfigReducer, {
   loadWorkingHoursSetting,
   settingsLoaded,
 } from './configSlice';
+import { initialiseDataTypes } from './searchSlice';
 
 vi.mock('loglevel');
 
 describe('configSlice', () => {
+  const originalActiveArea = staticChannels['active_area'];
+
+  beforeEach(() => {
+    staticChannels['active_area'] = JSON.parse(
+      JSON.stringify(originalActiveArea)
+    );
+  });
+
   // normally can test reducers in components, but since configSlice is high level
   // we'll create standalone unit tests for it
   describe('Reducer', () => {
@@ -95,6 +106,17 @@ describe('configSlice', () => {
 
       expect(updatedState.plotAxisSigFigs).toEqual('.3~s');
     });
+
+    it('should set dataTypes property when loadDataTypesSetting action is sent', () => {
+      expect(state.dataTypes).toEqual(undefined);
+
+      const updatedState = ConfigReducer(
+        state,
+        loadDataTypesSetting(['GS', 'GD'])
+      );
+
+      expect(updatedState.dataTypes).toEqual(['GS', 'GD']);
+    });
   });
 
   describe('Actions', () => {
@@ -102,7 +124,7 @@ describe('configSlice', () => {
       resetActions();
     });
 
-    it('settings are loaded and loadUrls, loadRecordLimitWarningSetting, loadPluginHost, loadWorkingHoursSetting and settingsLoaded actions are sent', async () => {
+    it('settings are loaded and loadUrls, loadRecordLimitWarningSetting, loadPluginHost, loadWorkingHoursSetting, and settingsLoaded actions are sent and data types are configured', async () => {
       setSettings(
         Promise.resolve({
           apiUrl: 'api',
@@ -118,12 +140,13 @@ describe('configSlice', () => {
           pluginHost: 'http://localhost:3000/',
           workingHours: { start: 10, end: 17 },
           plotAxisSigFigs: '.2~s',
+          dataTypes: ['GS', 'GD'],
         })
       );
       const asyncAction = configureApp();
       await asyncAction(dispatch);
 
-      expect(actions.length).toEqual(6);
+      expect(actions.length).toEqual(8);
       expect(actions).toContainEqual(
         loadUrls({
           apiUrl: 'api',
@@ -137,10 +160,14 @@ describe('configSlice', () => {
         loadWorkingHoursSetting({ start: 10, end: 17 })
       );
       expect(actions).toContainEqual(loadPlotAxisSigFigsSetting('.2~s'));
+      expect(actions).toContainEqual(loadDataTypesSetting(['GS', 'GD']));
+      expect(actions).toContainEqual(initialiseDataTypes(['GS', 'GD']));
+      expect(staticChannels['active_area'].name).toBe('Data Type');
+
       expect(actions).toContainEqual(settingsLoaded());
     });
 
-    it("doesn't send loadPluginHostSetting, loadPlotAxisSigFigsSetting and loadWorkingHoursSetting actions when they're not defined", async () => {
+    it("doesn't send loadPluginHostSetting, loadPlotAxisSigFigsSetting and loadWorkingHoursSetting actions or configure data types when they're not defined", async () => {
       setSettings(
         Promise.resolve({
           apiUrl: 'api',
@@ -169,6 +196,44 @@ describe('configSlice', () => {
       expect(
         actions.every(({ type }) => type !== loadPlotAxisSigFigsSetting.type)
       ).toBe(true);
+      expect(
+        actions.every(({ type }) => type !== loadDataTypesSetting.type)
+      ).toBe(true);
+      expect(
+        actions.every(({ type }) => type !== initialiseDataTypes.type)
+      ).toBe(true);
+      expect(staticChannels['active_area'].name).toBe('Active Area');
+
+      expect(actions).toContainEqual(settingsLoaded());
+    });
+
+    it("doesn't configure data types when it is an empty array", async () => {
+      setSettings(
+        Promise.resolve({
+          apiUrl: 'api',
+          recordLimitWarning: -1,
+          routes: [
+            {
+              section: 'section',
+              link: 'link',
+              displayName: 'displayName',
+              order: 1,
+            },
+          ],
+          dataTypes: [],
+        })
+      );
+
+      const asyncAction = configureApp();
+      await asyncAction(dispatch);
+
+      expect(
+        actions.every(({ type }) => type !== loadDataTypesSetting.type)
+      ).toBe(true);
+      expect(
+        actions.every(({ type }) => type !== initialiseDataTypes.type)
+      ).toBe(true);
+      expect(staticChannels['active_area'].name).toBe('Active Area');
 
       expect(actions).toContainEqual(settingsLoaded());
     });

--- a/src/state/slices/configSlice.tsx
+++ b/src/state/slices/configSlice.tsx
@@ -31,6 +31,7 @@ export const initialState: ConfigState = {
   pluginHost: '',
   settingsLoaded: false,
   workingHours: { start: 9, end: 18 },
+  dataTypes: undefined,
 };
 
 export const configSlice = createSlice({

--- a/src/state/slices/configSlice.tsx
+++ b/src/state/slices/configSlice.tsx
@@ -1,7 +1,11 @@
+import Category from '@mui/icons-material/Category';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
+import { staticChannels } from '../../api/channels';
+import { columnIconMappings } from '../../app.types';
 import { settings, type WorkingHours } from '../../settings';
 import { AppDispatch, RootState } from '../store';
+import { initialiseDataTypes } from './searchSlice';
 
 interface URLs {
   apiUrl: string;
@@ -15,6 +19,7 @@ interface ConfigState {
   settingsLoaded: boolean;
   workingHours: WorkingHours;
   plotAxisSigFigs?: string;
+  dataTypes?: string[];
 }
 
 // Define the initial state using that type
@@ -55,6 +60,9 @@ export const configSlice = createSlice({
     ) => {
       state.plotAxisSigFigs = action.payload;
     },
+    loadDataTypesSetting: (state, action: PayloadAction<string[]>) => {
+      state.dataTypes = action.payload;
+    },
   },
 });
 
@@ -65,6 +73,7 @@ export const {
   loadRecordLimitWarningSetting,
   loadWorkingHoursSetting,
   loadPlotAxisSigFigsSetting,
+  loadDataTypesSetting,
 } = configSlice.actions;
 
 export const selectUrls = (state: RootState) => state.config.urls;
@@ -74,6 +83,7 @@ export const selectWorkingHours = (state: RootState) =>
   state.config.workingHours;
 export const selectPlotAxisSigFigs = (state: RootState) =>
   state.config.plotAxisSigFigs;
+export const selectDataTypes = (state: RootState) => state.config.dataTypes;
 
 // Defining a thunk
 export const configureApp = () => async (dispatch: AppDispatch) => {
@@ -101,6 +111,17 @@ export const configureApp = () => async (dispatch: AppDispatch) => {
 
     if (settingsResult['plotAxisSigFigs'] !== undefined) {
       dispatch(loadPlotAxisSigFigsSetting(settingsResult['plotAxisSigFigs']));
+    }
+
+    const dataTypes = settingsResult['dataTypes'];
+    // if data types are defined, initialise everything to do with data types properly
+    if (Array.isArray(dataTypes) && dataTypes.length > 0) {
+      dispatch(loadDataTypesSetting(dataTypes));
+      // initialise selected data types to all of the options
+      dispatch(initialiseDataTypes(dataTypes));
+      // change active_area to read as data type
+      staticChannels['active_area'].name = 'Data Type';
+      columnIconMappings.set('active_area', <Category />);
     }
 
     dispatch(settingsLoaded());

--- a/src/state/slices/searchSlice.tsx
+++ b/src/state/slices/searchSlice.tsx
@@ -33,6 +33,7 @@ export const initialStateFunc = (): SearchState => {
       shotnumRange: {},
       maxShots: MAX_SHOTS_VALUES[0],
       experimentID: null,
+      dataTypes: undefined,
     },
   };
 };
@@ -46,10 +47,16 @@ export const searchSlice = createSlice({
     changeSearchParams: (state, action: PayloadAction<SearchParams>) => {
       state.searchParams = { ...action.payload };
     },
+    initialiseDataTypes: (
+      state,
+      action: PayloadAction<NonNullable<SearchParams['dataTypes']>>
+    ) => {
+      state.searchParams.dataTypes = action.payload;
+    },
   },
 });
 
-export const { changeSearchParams } = searchSlice.actions;
+export const { changeSearchParams, initialiseDataTypes } = searchSlice.actions;
 
 // Other code such as selectors can use the imported `RootState` type
 export const selectSearchParams = (state: RootState) =>

--- a/src/views/__snapshots__/viewTabs.component.test.tsx.snap
+++ b/src/views/__snapshots__/viewTabs.component.test.tsx.snap
@@ -455,6 +455,7 @@ exports[`View Tabs > renders correctly 1`] = `
                             <div
                               aria-label="open shot number search box"
                               class="MuiBox-root css-bm8stw"
+                              data-mui-internal-clone-element="true"
                             >
                               <svg
                                 aria-hidden="true"
@@ -467,7 +468,9 @@ exports[`View Tabs > renders correctly 1`] = `
                                   d="M12 2C6.49 2 2 6.49 2 12s4.49 10 10 10 10-4.49 10-10S17.51 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8m3-8c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3"
                                 />
                               </svg>
-                              <div>
+                              <div
+                                class="MuiBox-root css-0"
+                              >
                                 <p
                                   class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-cq7yze-MuiTypography-root"
                                 >
@@ -496,7 +499,7 @@ exports[`View Tabs > renders correctly 1`] = `
                       </div>
                     </div>
                     <div
-                      class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row css-12193pw-MuiGrid2-root"
+                      class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row css-1f35k3y-MuiGrid2-root"
                     >
                       <div
                         class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
@@ -784,7 +787,7 @@ exports[`View Tabs > renders correctly 1`] = `
                   >
                     <tr
                       class="MuiTableRow-root MuiTableRow-head css-o6za9h-MuiTableRow-root"
-                      data-rfd-droppable-context-id=":ro:"
+                      data-rfd-droppable-context-id=":rp:"
                       data-rfd-droppable-id="columns"
                     >
                       <th
@@ -872,7 +875,7 @@ exports[`View Tabs > renders correctly 1`] = `
                   />
                   <p
                     class="MuiTablePagination-selectLabel css-s09cke-MuiTablePagination-selectLabel"
-                    id=":rs:"
+                    id=":rt:"
                   >
                     Rows per page:
                   </p>
@@ -882,9 +885,9 @@ exports[`View Tabs > renders correctly 1`] = `
                     <div
                       aria-expanded="false"
                       aria-haspopup="listbox"
-                      aria-labelledby=":rs: :rr:"
+                      aria-labelledby=":rt: :rs:"
                       class="MuiSelect-select MuiTablePagination-select MuiSelect-standard MuiInputBase-input css-18zjd9i-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input"
-                      id=":rr:"
+                      id=":rs:"
                       role="combobox"
                       tabindex="0"
                     >

--- a/src/views/__snapshots__/viewTabs.component.test.tsx.snap
+++ b/src/views/__snapshots__/viewTabs.component.test.tsx.snap
@@ -234,7 +234,7 @@ exports[`View Tabs > renders correctly 1`] = `
                                       inputmode="text"
                                       placeholder="From..."
                                       type="text"
-                                      value="2024-07-14 12:00"
+                                      value="2022-01-02 00:00"
                                     />
                                     <div
                                       class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-standard MuiInputAdornment-sizeMedium css-1wulh66-MuiInputAdornment-root"
@@ -319,7 +319,7 @@ exports[`View Tabs > renders correctly 1`] = `
                                       inputmode="text"
                                       placeholder="To..."
                                       type="text"
-                                      value="2024-07-15 12:00"
+                                      value="2022-01-03 00:00"
                                     />
                                     <div
                                       class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-standard MuiInputAdornment-sizeMedium css-1wulh66-MuiInputAdornment-root"

--- a/src/views/viewTabs.component.test.tsx
+++ b/src/views/viewTabs.component.test.tsx
@@ -11,13 +11,12 @@ describe('View Tabs', () => {
 
   beforeEach(() => {
     user = userEvent.setup();
-    vi.useRealTimers();
+    vi.useFakeTimers({
+      toFake: ['Date'],
+    }).setSystemTime(new Date('2022-01-03 00:00:00'));
   });
 
   it('renders correctly', () => {
-    vi.useFakeTimers({
-      toFake: ['Date'],
-    }).setSystemTime(new Date('2024-07-15 12:00:00'));
     const { asFragment } = createView();
     expect(asFragment()).toMatchSnapshot();
   });


### PR DESCRIPTION
## Description
Add the ability to filter by data types - this is enabled by providing a non-empty array `dataTypes` in the settings. When this is provided, a few things happen:

- data type selector appears
- data types are sent with records queries
- data types are used to enable/disable shot num conversion
- shot nums are considered strings
- `active_area` will appear as `Data Type` instead of `Active Area` as well as have a different icon in the table

All this is to match Gemini functionality whilst still being backwards compatible with EPAC "mode". So this should be tested both against the normal server as well as against the specific Gemini service with the data types configured.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [x] Test with `dataTypes` set to `["GA","GD","GQ","GS"]` and point to Gemini server (ask me for the URL and credentials)
- [x] Test with no `dataTypes` provided against the normal server and verify functionality hasn't changed

## Agile board tracking
Closes DSEGOG-528 Closes DSEGOG-530