### PR TITLE
DSEGOG-529 configurable max shots

### DIFF
--- a/cypress/e2e/search.cy.ts
+++ b/cypress/e2e/search.cy.ts
@@ -1405,4 +1405,43 @@ describe('Search', () => {
       cy.contains('Click Search again to continue').should('not.exist');
     });
   });
+
+  it('with different max shots settings initialises correctly', () => {
+    let settings = Object.create(null);
+    cy.request('operationsgateway-settings.json').then((response) => {
+      settings = response.body;
+    });
+    cy.intercept('operationsgateway-settings.json', (req) => {
+      req.reply({
+        statusCode: 200,
+        body: {
+          ...settings,
+          recordLimitWarning: -1,
+          maxShots: [
+            { value: 100 },
+            { value: 500 },
+            { value: 'Unlimited', default: true },
+          ],
+        },
+      });
+    }).as('getSettings');
+
+    cy.visit('/').wait(['@getSettings']);
+
+    cy.findByRole('tabpanel', { name: 'Data' }).should('be.visible');
+    cy.findByRole('progressbar').should('not.exist');
+
+    cy.findByRole('radio', {
+      name: /Select 100 max shots/i,
+      checked: false,
+    }).should('exist');
+    cy.findByRole('radio', {
+      name: /Select 500 max shots/i,
+      checked: false,
+    }).should('exist');
+    cy.findByRole('radio', {
+      name: /Select Unlimited max shots/i,
+      checked: true,
+    }).should('exist');
+  });
 });

--- a/cypress/e2e/table.cy.ts
+++ b/cypress/e2e/table.cy.ts
@@ -263,7 +263,7 @@ describe('Table Component', () => {
 
   describe('can set max shots', () => {
     it('50 shots', () => {
-      cy.get('span[aria-label="Select unlimited max shots"]').should('exist');
+      cy.get('span[aria-label="Select Unlimited max shots"]').should('exist');
 
       cy.window().then((window) => {
         // Reference global instances set in "src/mocks/browser.js".
@@ -280,7 +280,7 @@ describe('Table Component', () => {
     });
 
     it('1000 shots', () => {
-      cy.get('span[aria-label="Select unlimited max shots"]').should('exist');
+      cy.get('span[aria-label="Select Unlimited max shots"]').should('exist');
 
       cy.window().then(async (window) => {
         // Reference global instances set in "src/mocks/browser.js".
@@ -299,7 +299,7 @@ describe('Table Component', () => {
     });
 
     it('unlimited shots', () => {
-      cy.get('span[aria-label="Select unlimited max shots"]').should('exist');
+      cy.get('span[aria-label="Select Unlimited max shots"]').should('exist');
 
       cy.window().then((window) => {
         // Reference global instances set in "src/mocks/browser.js".
@@ -312,7 +312,7 @@ describe('Table Component', () => {
         );
       });
 
-      cy.get('span[aria-label="Select unlimited max shots"]').click();
+      cy.get('span[aria-label="Select Unlimited max shots"]').click();
       cy.contains('Search').click();
       cy.contains('1–25 of 2500');
     });

--- a/public/operationsgateway-settings.example.json
+++ b/public/operationsgateway-settings.example.json
@@ -1,6 +1,11 @@
 {
   "apiUrl": "",
   "recordLimitWarning": -1,
+  "maxShots": [
+    { "value": 50, "default": true },
+    { "value": 1000 },
+    { "value": "Unlimited" }
+  ],
   "workingHours": { "start": 9, "end": 18 },
   "plotAxisSigFigs": ".3~s",
   "routes": [

--- a/server/e2e-settings-mocked.json
+++ b/server/e2e-settings-mocked.json
@@ -1,6 +1,11 @@
 {
   "apiUrl": "",
   "recordLimitWarning": -1,
+  "maxShots": [
+    { "value": 50, "default": true },
+    { "value": 1000 },
+    { "value": "Unlimited" }
+  ],
   "workingHours": { "start": 9, "end": 18 },
   "plotAxisSigFigs": ".3~s",
   "routes": [

--- a/server/e2e-settings-real.json
+++ b/server/e2e-settings-real.json
@@ -1,6 +1,11 @@
 {
   "apiUrl": "http://host.docker.internal:8000",
   "recordLimitWarning": -1,
+  "maxShots": [
+    { "value": 50, "default": true },
+    { "value": 1000 },
+    { "value": "Unlimited" }
+  ],
   "workingHours": { "start": 9, "end": 18 },
   "plotAxisSigFigs": ".3~s",
   "routes": [

--- a/src/api/records.test.tsx
+++ b/src/api/records.test.tsx
@@ -13,7 +13,10 @@ import { operators, parseFilter, Token } from '../filtering/filterParser';
 import handleOG_APIError from '../handleOG_APIError';
 import recordsJson from '../mocks/records.json';
 import { server } from '../mocks/server';
-import { MAX_SHOTS_VALUES } from '../search/components/maxShots.component';
+import {
+  defaultMaxShots,
+  getDefaultMaxShot,
+} from '../state/slices/searchSlice';
 import { RootState } from '../state/store';
 import {
   createTestQueryClient,
@@ -76,7 +79,7 @@ describe('records api functions', () => {
               fromDate: '2022-01-01 00:00:00',
               toDate: '2022-01-02 00:00:00',
             },
-            maxShots: MAX_SHOTS_VALUES[0],
+            maxShots: getDefaultMaxShot(defaultMaxShots),
           },
         },
         filter: {
@@ -320,7 +323,7 @@ describe('records api functions', () => {
           toDate: '2022-01-02 00:00:00',
         },
         shotnumRange: {},
-        maxShots: MAX_SHOTS_VALUES[0],
+        maxShots: getDefaultMaxShot(defaultMaxShots),
         experimentID: null,
       };
 
@@ -365,7 +368,7 @@ describe('records api functions', () => {
               fromDate: '2022-01-01 00:00:00',
               toDate: '2022-01-02 00:00:00',
             },
-            maxShots: MAX_SHOTS_VALUES[0],
+            maxShots: getDefaultMaxShot(defaultMaxShots),
           },
         },
         filter: {
@@ -473,7 +476,7 @@ describe('records api functions', () => {
               fromDate: '2022-01-01 00:00:00',
               toDate: '2022-01-02 00:00:00',
             },
-            maxShots: MAX_SHOTS_VALUES[0],
+            maxShots: getDefaultMaxShot(defaultMaxShots),
           },
         },
         filter: {
@@ -956,7 +959,7 @@ describe('records api functions', () => {
               fromDate: '2022-01-01 00:00:00',
               toDate: '2022-01-02 00:00:00',
             },
-            maxShots: MAX_SHOTS_VALUES[0],
+            maxShots: getDefaultMaxShot(defaultMaxShots),
           },
         },
         filter: {
@@ -1026,7 +1029,7 @@ describe('records api functions', () => {
               fromDate: '2022-01-01 00:00:00',
               toDate: '2022-01-02 00:00:00',
             },
-            maxShots: MAX_SHOTS_VALUES[0],
+            maxShots: getDefaultMaxShot(defaultMaxShots),
           },
         },
         filter: {

--- a/src/api/records.test.tsx
+++ b/src/api/records.test.tsx
@@ -14,7 +14,7 @@ import handleOG_APIError from '../handleOG_APIError';
 import recordsJson from '../mocks/records.json';
 import { server } from '../mocks/server';
 import {
-  defaultMaxShots,
+  defaultMaxShotOptions,
   getDefaultMaxShot,
 } from '../state/slices/searchSlice';
 import { RootState } from '../state/store';
@@ -79,7 +79,7 @@ describe('records api functions', () => {
               fromDate: '2022-01-01 00:00:00',
               toDate: '2022-01-02 00:00:00',
             },
-            maxShots: getDefaultMaxShot(defaultMaxShots),
+            maxShots: getDefaultMaxShot(defaultMaxShotOptions),
           },
         },
         filter: {
@@ -323,7 +323,7 @@ describe('records api functions', () => {
           toDate: '2022-01-02 00:00:00',
         },
         shotnumRange: {},
-        maxShots: getDefaultMaxShot(defaultMaxShots),
+        maxShots: getDefaultMaxShot(defaultMaxShotOptions),
         experimentID: null,
       };
 
@@ -368,7 +368,7 @@ describe('records api functions', () => {
               fromDate: '2022-01-01 00:00:00',
               toDate: '2022-01-02 00:00:00',
             },
-            maxShots: getDefaultMaxShot(defaultMaxShots),
+            maxShots: getDefaultMaxShot(defaultMaxShotOptions),
           },
         },
         filter: {
@@ -476,7 +476,7 @@ describe('records api functions', () => {
               fromDate: '2022-01-01 00:00:00',
               toDate: '2022-01-02 00:00:00',
             },
-            maxShots: getDefaultMaxShot(defaultMaxShots),
+            maxShots: getDefaultMaxShot(defaultMaxShotOptions),
           },
         },
         filter: {
@@ -959,7 +959,7 @@ describe('records api functions', () => {
               fromDate: '2022-01-01 00:00:00',
               toDate: '2022-01-02 00:00:00',
             },
-            maxShots: getDefaultMaxShot(defaultMaxShots),
+            maxShots: getDefaultMaxShot(defaultMaxShotOptions),
           },
         },
         filter: {
@@ -1029,7 +1029,7 @@ describe('records api functions', () => {
               fromDate: '2022-01-01 00:00:00',
               toDate: '2022-01-02 00:00:00',
             },
-            maxShots: getDefaultMaxShot(defaultMaxShots),
+            maxShots: getDefaultMaxShot(defaultMaxShotOptions),
           },
         },
         filter: {

--- a/src/search/components/__snapshots__/maxShots.component.test.tsx.snap
+++ b/src/search/components/__snapshots__/maxShots.component.test.tsx.snap
@@ -123,7 +123,7 @@ exports[`maxShots search > renders correctly with a selected value 1`] = `
             class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
           >
             <span
-              aria-label="Select unlimited max shots"
+              aria-label="Select Unlimited max shots"
               class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1q72ply-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
             >
               <input

--- a/src/search/components/maxShots.component.test.tsx
+++ b/src/search/components/maxShots.component.test.tsx
@@ -5,6 +5,7 @@ import {
   type RenderResult,
 } from '@testing-library/react';
 import userEvent, { UserEvent } from '@testing-library/user-event';
+import { defaultMaxShots } from '../../state/slices/searchSlice';
 import MaxShots, { type MaxShotsProps } from './maxShots.component';
 
 describe('maxShots search', () => {
@@ -23,6 +24,7 @@ describe('maxShots search', () => {
   it('renders correctly with a selected value', () => {
     props = {
       maxShots: 50,
+      maxShotsOptions: defaultMaxShots,
       changeMaxShots,
       searchParamsUpdated,
     };
@@ -46,6 +48,7 @@ describe('maxShots search', () => {
     it('50 shots', async () => {
       props = {
         maxShots: 100,
+        maxShotsOptions: defaultMaxShots,
         changeMaxShots,
         searchParamsUpdated,
       };
@@ -64,6 +67,7 @@ describe('maxShots search', () => {
     it('1000 shots', async () => {
       props = {
         maxShots: 50,
+        maxShotsOptions: defaultMaxShots,
         changeMaxShots,
         searchParamsUpdated,
       };
@@ -82,6 +86,7 @@ describe('maxShots search', () => {
     it('unlimited', async () => {
       props = {
         maxShots: 50,
+        maxShotsOptions: defaultMaxShots,
         changeMaxShots,
         searchParamsUpdated,
       };
@@ -91,7 +96,7 @@ describe('maxShots search', () => {
         name: 'select max shots',
       });
       await user.click(
-        within(maxShotsRadioGroup).getByLabelText('Select unlimited max shots')
+        within(maxShotsRadioGroup).getByLabelText('Select Unlimited max shots')
       );
       expect(changeMaxShots).toHaveBeenCalledWith(Infinity);
       expect(searchParamsUpdated).toHaveBeenCalled();

--- a/src/search/components/maxShots.component.test.tsx
+++ b/src/search/components/maxShots.component.test.tsx
@@ -5,7 +5,7 @@ import {
   type RenderResult,
 } from '@testing-library/react';
 import userEvent, { UserEvent } from '@testing-library/user-event';
-import { defaultMaxShots } from '../../state/slices/searchSlice';
+import { defaultMaxShotOptions } from '../../state/slices/searchSlice';
 import MaxShots, { type MaxShotsProps } from './maxShots.component';
 
 describe('maxShots search', () => {
@@ -24,7 +24,7 @@ describe('maxShots search', () => {
   it('renders correctly with a selected value', () => {
     props = {
       maxShots: 50,
-      maxShotsOptions: defaultMaxShots,
+      maxShotsOptions: defaultMaxShotOptions,
       changeMaxShots,
       searchParamsUpdated,
     };
@@ -48,7 +48,7 @@ describe('maxShots search', () => {
     it('50 shots', async () => {
       props = {
         maxShots: 100,
-        maxShotsOptions: defaultMaxShots,
+        maxShotsOptions: defaultMaxShotOptions,
         changeMaxShots,
         searchParamsUpdated,
       };
@@ -67,7 +67,7 @@ describe('maxShots search', () => {
     it('1000 shots', async () => {
       props = {
         maxShots: 50,
-        maxShotsOptions: defaultMaxShots,
+        maxShotsOptions: defaultMaxShotOptions,
         changeMaxShots,
         searchParamsUpdated,
       };
@@ -86,7 +86,7 @@ describe('maxShots search', () => {
     it('unlimited', async () => {
       props = {
         maxShots: 50,
-        maxShotsOptions: defaultMaxShots,
+        maxShotsOptions: defaultMaxShotOptions,
         changeMaxShots,
         searchParamsUpdated,
       };

--- a/src/search/components/maxShots.component.tsx
+++ b/src/search/components/maxShots.component.tsx
@@ -8,19 +8,18 @@ import {
 } from '@mui/material';
 import React from 'react';
 import { SearchParams } from '../../app.types';
-import { useAppSelector } from '../../state/hooks';
-import { selectMaxShots } from '../../state/slices/configSlice';
+import { MaxShotType } from '../../settings';
 
 export interface MaxShotsProps {
   maxShots: SearchParams['maxShots'];
+  maxShotsOptions: MaxShotType[];
   changeMaxShots: (maxShots: SearchParams['maxShots']) => void;
   searchParamsUpdated: () => void;
 }
 
 const MaxShots = (props: MaxShotsProps): React.ReactElement => {
-  const { maxShots, changeMaxShots, searchParamsUpdated } = props;
-
-  const maxShotsOptions = useAppSelector(selectMaxShots);
+  const { maxShots, maxShotsOptions, changeMaxShots, searchParamsUpdated } =
+    props;
 
   return (
     <Box sx={{ position: 'relative' }}>

--- a/src/search/components/maxShots.component.tsx
+++ b/src/search/components/maxShots.component.tsx
@@ -8,8 +8,8 @@ import {
 } from '@mui/material';
 import React from 'react';
 import { SearchParams } from '../../app.types';
-
-export const MAX_SHOTS_VALUES = [50, 1000, Infinity];
+import { useAppSelector } from '../../state/hooks';
+import { selectMaxShots } from '../../state/slices/configSlice';
 
 export interface MaxShotsProps {
   maxShots: SearchParams['maxShots'];
@@ -19,6 +19,8 @@ export interface MaxShotsProps {
 
 const MaxShots = (props: MaxShotsProps): React.ReactElement => {
   const { maxShots, changeMaxShots, searchParamsUpdated } = props;
+
+  const maxShotsOptions = useAppSelector(selectMaxShots);
 
   return (
     <Box sx={{ position: 'relative' }}>
@@ -51,18 +53,12 @@ const MaxShots = (props: MaxShotsProps): React.ReactElement => {
               changeMaxShots(Number(value));
             }}
           >
-            {MAX_SHOTS_VALUES.map((value, i) => (
+            {maxShotsOptions.map(({ value }, i) => (
               <FormControlLabel
                 key={i}
-                value={value}
-                control={
-                  <Radio
-                    aria-label={`Select ${
-                      value === Infinity ? 'unlimited' : value
-                    } max shots`}
-                  />
-                }
-                label={value === Infinity ? 'Unlimited' : value}
+                value={value === 'Unlimited' ? Infinity : value}
+                control={<Radio aria-label={`Select ${value} max shots`} />}
+                label={value}
               />
             ))}
           </RadioGroup>

--- a/src/search/searchBar.component.test.tsx
+++ b/src/search/searchBar.component.test.tsx
@@ -13,7 +13,7 @@ import { formatDateTimeForApi } from '../api/api';
 import recordsJson from '../mocks/records.json';
 import { server } from '../mocks/server';
 import {
-  defaultMaxShots,
+  defaultMaxShotOptions,
   getDefaultMaxShot,
 } from '../state/slices/searchSlice';
 import { RootState } from '../state/store';
@@ -308,7 +308,7 @@ describe('searchBar component', () => {
         min: 1,
         max: 2,
       },
-      maxShots: getDefaultMaxShot(defaultMaxShots),
+      maxShots: getDefaultMaxShot(defaultMaxShotOptions),
       experimentID: null,
     });
   });
@@ -331,7 +331,7 @@ describe('searchBar component', () => {
         toDate: '2024-07-02T12:00:59',
       },
       shotnumRange: {},
-      maxShots: getDefaultMaxShot(defaultMaxShots),
+      maxShots: getDefaultMaxShot(defaultMaxShotOptions),
       experimentID: null,
     });
   });
@@ -481,7 +481,7 @@ describe('searchBar component', () => {
       dateRange: {},
       experimentID: null,
       shotnumRange: {},
-      maxShots: getDefaultMaxShot(defaultMaxShots),
+      maxShots: getDefaultMaxShot(defaultMaxShotOptions),
     });
 
     // Try search again
@@ -497,7 +497,7 @@ describe('searchBar component', () => {
         min: 1,
         max: 18,
       },
-      maxShots: getDefaultMaxShot(defaultMaxShots),
+      maxShots: getDefaultMaxShot(defaultMaxShotOptions),
       experimentID: null,
     });
   });
@@ -656,7 +656,7 @@ describe('searchBar component', () => {
         min: 1,
         max: 18,
       },
-      maxShots: getDefaultMaxShot(defaultMaxShots),
+      maxShots: getDefaultMaxShot(defaultMaxShotOptions),
       experimentID: null,
     });
   });

--- a/src/search/searchBar.component.test.tsx
+++ b/src/search/searchBar.component.test.tsx
@@ -12,9 +12,12 @@ import React from 'react';
 import { formatDateTimeForApi } from '../api/api';
 import recordsJson from '../mocks/records.json';
 import { server } from '../mocks/server';
+import {
+  defaultMaxShots,
+  getDefaultMaxShot,
+} from '../state/slices/searchSlice';
 import { RootState } from '../state/store';
 import { getInitialState, renderComponentWithProviders } from '../testUtils';
-import { MAX_SHOTS_VALUES } from './components/maxShots.component';
 import SearchBar from './searchBar.component';
 
 describe('searchBar component', () => {
@@ -305,7 +308,7 @@ describe('searchBar component', () => {
         min: 1,
         max: 2,
       },
-      maxShots: MAX_SHOTS_VALUES[0],
+      maxShots: getDefaultMaxShot(defaultMaxShots),
       experimentID: null,
     });
   });
@@ -328,7 +331,7 @@ describe('searchBar component', () => {
         toDate: '2024-07-02T12:00:59',
       },
       shotnumRange: {},
-      maxShots: MAX_SHOTS_VALUES[0],
+      maxShots: getDefaultMaxShot(defaultMaxShots),
       experimentID: null,
     });
   });
@@ -478,7 +481,7 @@ describe('searchBar component', () => {
       dateRange: {},
       experimentID: null,
       shotnumRange: {},
-      maxShots: MAX_SHOTS_VALUES[0],
+      maxShots: getDefaultMaxShot(defaultMaxShots),
     });
 
     // Try search again
@@ -494,7 +497,7 @@ describe('searchBar component', () => {
         min: 1,
         max: 18,
       },
-      maxShots: MAX_SHOTS_VALUES[0],
+      maxShots: getDefaultMaxShot(defaultMaxShots),
       experimentID: null,
     });
   });
@@ -653,7 +656,7 @@ describe('searchBar component', () => {
         min: 1,
         max: 18,
       },
-      maxShots: MAX_SHOTS_VALUES[0],
+      maxShots: getDefaultMaxShot(defaultMaxShots),
       experimentID: null,
     });
   });

--- a/src/search/searchBar.component.tsx
+++ b/src/search/searchBar.component.tsx
@@ -649,6 +649,7 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
           <Grid>
             <MaxShots
               maxShots={maxShots}
+              maxShotsOptions={maxShotsOptions}
               changeMaxShots={setMaxShots}
               searchParamsUpdated={searchParamsUpdated}
             />

--- a/src/search/searchBar.component.tsx
+++ b/src/search/searchBar.component.tsx
@@ -24,10 +24,14 @@ import {
   ShotnumRange,
 } from '../app.types';
 import { useAppDispatch, useAppSelector } from '../state/hooks';
-import { selectRecordLimitWarning } from '../state/slices/configSlice';
+import {
+  selectMaxShots,
+  selectRecordLimitWarning,
+} from '../state/slices/configSlice';
 import { selectQueryFilters } from '../state/slices/filterSlice';
 import {
   changeSearchParams,
+  getDefaultMaxShot,
   selectDateRangeInLocalTime,
   selectSearchParams,
 } from '../state/slices/searchSlice';
@@ -35,7 +39,7 @@ import AutoRefreshToggle from './components/autoRefreshToggle.component';
 import DataRefresh from './components/dataRefresh.component';
 import DateTime from './components/dateTime.component';
 import Experiment from './components/experiment.component';
-import MaxShots, { MAX_SHOTS_VALUES } from './components/maxShots.component';
+import MaxShots from './components/maxShots.component';
 import ShotNumber from './components/shotNumber.component';
 import Timeframe, {
   type TimeframeRange,
@@ -62,6 +66,7 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
   const searchParams = useAppSelector(selectSearchParams); // the parameters sent to the search query itself
   const { shotnumRange, maxShots: maxShotsParam, experimentID } = searchParams;
   const dateRangeLocalTime = useAppSelector(selectDateRangeInLocalTime);
+  const maxShotsOptions = useAppSelector(selectMaxShots);
 
   // we need filters so we can check for past queries before showing the warning message
   const filters = useAppSelector(selectQueryFilters);
@@ -345,9 +350,10 @@ const SearchBar = (props: SearchBarProps): React.ReactElement => {
       setSearchParameterToDate(null);
       setSearchParameterShotnumMin(undefined);
       setSearchParameterShotnumMax(undefined);
-      setMaxShots(MAX_SHOTS_VALUES[0]);
+      setMaxShots(getDefaultMaxShot(maxShotsOptions));
       setTimeframeRange(null);
     } else firstUpdate.current = false;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId]);
 
   const searchParamsUpdated = () => {

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -4,6 +4,7 @@ import { MicroFrontendId } from './app.types';
 import { server } from './mocks/server';
 import { fetchSettings } from './settings';
 import { registerRoute } from './state/scigateway.actions';
+import { defaultMaxShots } from './state/slices/searchSlice';
 
 vi.mock('loglevel');
 
@@ -22,6 +23,7 @@ describe('fetchSettings', () => {
     const settingsResult = {
       apiUrl: 'api',
       recordLimitWarning: -1,
+      maxShots: defaultMaxShots,
       routes: [
         {
           section: 'section',
@@ -68,6 +70,7 @@ describe('fetchSettings', () => {
     const settingsResult = {
       apiUrl: 'api',
       recordLimitWarning: -1,
+      maxShots: defaultMaxShots,
       routes: [
         {
           section: 'section0',
@@ -178,6 +181,83 @@ describe('fetchSettings', () => {
     );
   });
 
+  it('logs an error if maxShots is not defined in the settings', async () => {
+    server.use(
+      http.get('/operationsgateway-settings.json', () =>
+        HttpResponse.json(
+          {
+            apiUrl: 'api',
+            recordLimitWarning: -1,
+          },
+          { status: 200 }
+        )
+      )
+    );
+
+    const settings = await fetchSettings();
+
+    expect(settings).toBeUndefined();
+    expect(log.error).toHaveBeenCalled();
+
+    const mockLog = vi.mocked(log.error).mock;
+    expect(mockLog.calls[0][0]).toEqual(
+      'Error loading /operationsgateway-settings.json: maxShots is undefined in settings'
+    );
+  });
+
+  it('logs an error if more than one default maxShots is defined in the settings', async () => {
+    server.use(
+      http.get('/operationsgateway-settings.json', () =>
+        HttpResponse.json(
+          {
+            apiUrl: 'api',
+            recordLimitWarning: -1,
+            maxShots: [
+              { value: 50, default: true },
+              { value: 100, default: true },
+            ],
+          },
+          { status: 200 }
+        )
+      )
+    );
+
+    const settings = await fetchSettings();
+
+    expect(settings).toBeUndefined();
+    expect(log.error).toHaveBeenCalled();
+
+    const mockLog = vi.mocked(log.error).mock;
+    expect(mockLog.calls[0][0]).toEqual(
+      'Error loading /operationsgateway-settings.json: More than one default max shot is defined in the settings'
+    );
+  });
+
+  it('logs an error if one of the maxShots is an invalid type in the settings', async () => {
+    server.use(
+      http.get('/operationsgateway-settings.json', () =>
+        HttpResponse.json(
+          {
+            apiUrl: 'api',
+            recordLimitWarning: -1,
+            maxShots: [{ value: 'random string' }],
+          },
+          { status: 200 }
+        )
+      )
+    );
+
+    const settings = await fetchSettings();
+
+    expect(settings).toBeUndefined();
+    expect(log.error).toHaveBeenCalled();
+
+    const mockLog = vi.mocked(log.error).mock;
+    expect(mockLog.calls[0][0]).toEqual(
+      'Error loading /operationsgateway-settings.json: Some max shots have a non-number, non-"Unlimited" value in the settings'
+    );
+  });
+
   it('logs an error if settings.json is an invalid JSON object', async () => {
     server.use(
       http.get('/operationsgateway-settings.json', () =>
@@ -245,6 +325,7 @@ describe('fetchSettings', () => {
           {
             apiUrl: 'api',
             recordLimitWarning: -1,
+            maxShots: defaultMaxShots,
           },
           { status: 200 }
         )
@@ -269,6 +350,8 @@ describe('fetchSettings', () => {
           {
             apiUrl: 'api',
             recordLimitWarning: -1,
+            maxShots: defaultMaxShots,
+
             routes: [
               {
                 section: 'section',

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -4,7 +4,7 @@ import { MicroFrontendId } from './app.types';
 import { server } from './mocks/server';
 import { fetchSettings } from './settings';
 import { registerRoute } from './state/scigateway.actions';
-import { defaultMaxShots } from './state/slices/searchSlice';
+import { defaultMaxShotOptions } from './state/slices/searchSlice';
 
 vi.mock('loglevel');
 
@@ -23,7 +23,7 @@ describe('fetchSettings', () => {
     const settingsResult = {
       apiUrl: 'api',
       recordLimitWarning: -1,
-      maxShots: defaultMaxShots,
+      maxShots: defaultMaxShotOptions,
       routes: [
         {
           section: 'section',
@@ -70,7 +70,7 @@ describe('fetchSettings', () => {
     const settingsResult = {
       apiUrl: 'api',
       recordLimitWarning: -1,
-      maxShots: defaultMaxShots,
+      maxShots: defaultMaxShotOptions,
       routes: [
         {
           section: 'section0',
@@ -325,7 +325,7 @@ describe('fetchSettings', () => {
           {
             apiUrl: 'api',
             recordLimitWarning: -1,
-            maxShots: defaultMaxShots,
+            maxShots: defaultMaxShotOptions,
           },
           { status: 200 }
         )
@@ -350,7 +350,7 @@ describe('fetchSettings', () => {
           {
             apiUrl: 'api',
             recordLimitWarning: -1,
-            maxShots: defaultMaxShots,
+            maxShots: defaultMaxShotOptions,
 
             routes: [
               {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,9 +10,15 @@ export interface WorkingHours {
   end: number;
 }
 
+export interface MaxShotType {
+  value: number | 'Unlimited'; // JSON doesn't support infinity as a number so have to use a string
+  default?: boolean;
+}
+
 export interface OperationsGatewaySettings {
   apiUrl: string;
   recordLimitWarning: number;
+  maxShots: MaxShotType[];
   routes: PluginRoute[];
   helpSteps?: { target: string; content: string }[];
   pluginHost?: string;
@@ -50,6 +56,25 @@ export const fetchSettings = (): Promise<OperationsGatewaySettings | void> => {
       // Ensure a limit on how many records can be requested before displaying a warning is present
       if (!('recordLimitWarning' in settings)) {
         throw new Error('recordLimitWarning is undefined in settings');
+      }
+
+      // Ensure max shots definition is present and that no more than 1 is default and valid value type
+      if (!('maxShots' in settings)) {
+        throw new Error('maxShots is undefined in settings');
+      }
+      if (settings.maxShots.filter((x) => x.default === true).length > 1) {
+        throw new Error(
+          'More than one default max shot is defined in the settings'
+        );
+      }
+      if (
+        settings.maxShots.some(
+          (x) => typeof x.value !== 'number' && x.value !== 'Unlimited'
+        )
+      ) {
+        throw new Error(
+          'Some max shots have a non-number, non-"Unlimited" value in the settings'
+        );
       }
 
       if (Array.isArray(settings['routes']) && settings['routes'].length) {

--- a/src/state/slices/configSlice.test.tsx
+++ b/src/state/slices/configSlice.test.tsx
@@ -3,6 +3,7 @@ import { actions, dispatch, resetActions } from '../../testUtils';
 import ConfigReducer, {
   configureApp,
   initialState,
+  loadMaxShotsSetting,
   loadPlotAxisSigFigsSetting,
   loadPluginHostSetting,
   loadRecordLimitWarningSetting,
@@ -10,6 +11,7 @@ import ConfigReducer, {
   loadWorkingHoursSetting,
   settingsLoaded,
 } from './configSlice';
+import { defaultMaxShots, initialiseDefaultMaxShots } from './searchSlice';
 
 vi.mock('loglevel');
 
@@ -74,6 +76,23 @@ describe('configSlice', () => {
       expect(updatedState.recordLimitWarning).toEqual(10);
     });
 
+    it('should set maxShots property when loadMaxShotsSetting action is sent', () => {
+      expect(state.maxShots).toEqual(defaultMaxShots);
+
+      const updatedState = ConfigReducer(
+        state,
+        loadMaxShotsSetting([
+          { value: 100, default: true },
+          { value: 'Unlimited' },
+        ])
+      );
+
+      expect(updatedState.maxShots).toEqual([
+        { value: 100, default: true },
+        { value: 'Unlimited' },
+      ]);
+    });
+
     it('should set workingHours property when loadWorkingHoursSetting action is sent', () => {
       expect(state.workingHours).toEqual({ start: 9, end: 18 });
 
@@ -107,6 +126,7 @@ describe('configSlice', () => {
         Promise.resolve({
           apiUrl: 'api',
           recordLimitWarning: -1,
+          maxShots: [{ value: 100, default: true }, { value: 'Unlimited' }],
           routes: [
             {
               section: 'section',
@@ -123,13 +143,25 @@ describe('configSlice', () => {
       const asyncAction = configureApp();
       await asyncAction(dispatch);
 
-      expect(actions.length).toEqual(6);
+      expect(actions.length).toEqual(8);
       expect(actions).toContainEqual(
         loadUrls({
           apiUrl: 'api',
         })
       );
       expect(actions).toContainEqual(loadRecordLimitWarningSetting(-1));
+      expect(actions).toContainEqual(
+        loadMaxShotsSetting([
+          { value: 100, default: true },
+          { value: 'Unlimited' },
+        ])
+      );
+      expect(actions).toContainEqual(
+        initialiseDefaultMaxShots([
+          { value: 100, default: true },
+          { value: 'Unlimited' },
+        ])
+      );
       expect(actions).toContainEqual(
         loadPluginHostSetting('http://localhost:3000/')
       );
@@ -145,6 +177,7 @@ describe('configSlice', () => {
         Promise.resolve({
           apiUrl: 'api',
           recordLimitWarning: -1,
+          maxShots: defaultMaxShots,
           routes: [
             {
               section: 'section',
@@ -159,7 +192,7 @@ describe('configSlice', () => {
       const asyncAction = configureApp();
       await asyncAction(dispatch);
 
-      expect(actions.length).toEqual(3);
+      expect(actions.length).toEqual(5);
       expect(
         actions.every(({ type }) => type !== loadPluginHostSetting.type)
       ).toBe(true);

--- a/src/state/slices/configSlice.test.tsx
+++ b/src/state/slices/configSlice.test.tsx
@@ -169,7 +169,7 @@ describe('configSlice', () => {
       const asyncAction = configureApp();
       await asyncAction(dispatch);
 
-      expect(actions.length).toEqual(8);
+      expect(actions.length).toEqual(10);
       expect(actions).toContainEqual(
         loadUrls({
           apiUrl: 'api',

--- a/src/state/slices/configSlice.test.tsx
+++ b/src/state/slices/configSlice.test.tsx
@@ -11,7 +11,10 @@ import ConfigReducer, {
   loadWorkingHoursSetting,
   settingsLoaded,
 } from './configSlice';
-import { defaultMaxShots, initialiseDefaultMaxShots } from './searchSlice';
+import {
+  defaultMaxShotOptions,
+  initialiseDefaultMaxShots,
+} from './searchSlice';
 
 vi.mock('loglevel');
 
@@ -77,7 +80,7 @@ describe('configSlice', () => {
     });
 
     it('should set maxShots property when loadMaxShotsSetting action is sent', () => {
-      expect(state.maxShots).toEqual(defaultMaxShots);
+      expect(state.maxShots).toEqual(defaultMaxShotOptions);
 
       const updatedState = ConfigReducer(
         state,
@@ -177,7 +180,7 @@ describe('configSlice', () => {
         Promise.resolve({
           apiUrl: 'api',
           recordLimitWarning: -1,
-          maxShots: defaultMaxShots,
+          maxShots: defaultMaxShotOptions,
           routes: [
             {
               section: 'section',

--- a/src/state/slices/configSlice.tsx
+++ b/src/state/slices/configSlice.tsx
@@ -1,7 +1,8 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
-import { settings, type WorkingHours } from '../../settings';
+import { MaxShotType, settings, type WorkingHours } from '../../settings';
 import { AppDispatch, RootState } from '../store';
+import { defaultMaxShots, initialiseDefaultMaxShots } from './searchSlice';
 
 interface URLs {
   apiUrl: string;
@@ -11,6 +12,7 @@ interface URLs {
 interface ConfigState {
   urls: URLs;
   recordLimitWarning: number;
+  maxShots: MaxShotType[];
   pluginHost: string;
   settingsLoaded: boolean;
   workingHours: WorkingHours;
@@ -23,6 +25,7 @@ export const initialState: ConfigState = {
     apiUrl: '',
   },
   recordLimitWarning: -1,
+  maxShots: defaultMaxShots,
   pluginHost: '',
   settingsLoaded: false,
   workingHours: { start: 9, end: 18 },
@@ -46,6 +49,9 @@ export const configSlice = createSlice({
     loadRecordLimitWarningSetting: (state, action: PayloadAction<number>) => {
       state.recordLimitWarning = action.payload;
     },
+    loadMaxShotsSetting: (state, action: PayloadAction<MaxShotType[]>) => {
+      state.maxShots = action.payload;
+    },
     loadWorkingHoursSetting: (state, action: PayloadAction<WorkingHours>) => {
       state.workingHours = action.payload;
     },
@@ -63,6 +69,7 @@ export const {
   loadPluginHostSetting,
   loadUrls,
   loadRecordLimitWarningSetting,
+  loadMaxShotsSetting,
   loadWorkingHoursSetting,
   loadPlotAxisSigFigsSetting,
 } = configSlice.actions;
@@ -70,6 +77,7 @@ export const {
 export const selectUrls = (state: RootState) => state.config.urls;
 export const selectRecordLimitWarning = (state: RootState) =>
   state.config.recordLimitWarning;
+export const selectMaxShots = (state: RootState) => state.config.maxShots;
 export const selectWorkingHours = (state: RootState) =>
   state.config.workingHours;
 export const selectPlotAxisSigFigs = (state: RootState) =>
@@ -85,11 +93,12 @@ export const configureApp = () => async (dispatch: AppDispatch) => {
       })
     );
 
-    if (settingsResult['recordLimitWarning'] !== undefined) {
-      dispatch(
-        loadRecordLimitWarningSetting(settingsResult['recordLimitWarning'])
-      );
-    }
+    dispatch(
+      loadRecordLimitWarningSetting(settingsResult['recordLimitWarning'])
+    );
+
+    dispatch(loadMaxShotsSetting(settingsResult['maxShots']));
+    dispatch(initialiseDefaultMaxShots(settingsResult['maxShots']));
 
     if (settingsResult['pluginHost'] !== undefined) {
       dispatch(loadPluginHostSetting(settingsResult['pluginHost']));

--- a/src/state/slices/configSlice.tsx
+++ b/src/state/slices/configSlice.tsx
@@ -2,7 +2,10 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import { MaxShotType, settings, type WorkingHours } from '../../settings';
 import { AppDispatch, RootState } from '../store';
-import { defaultMaxShots, initialiseDefaultMaxShots } from './searchSlice';
+import {
+  defaultMaxShotOptions,
+  initialiseDefaultMaxShots,
+} from './searchSlice';
 
 interface URLs {
   apiUrl: string;
@@ -25,7 +28,7 @@ export const initialState: ConfigState = {
     apiUrl: '',
   },
   recordLimitWarning: -1,
-  maxShots: defaultMaxShots,
+  maxShots: defaultMaxShotOptions,
   pluginHost: '',
   settingsLoaded: false,
   workingHours: { start: 9, end: 18 },

--- a/src/state/slices/searchSlice.test.tsx
+++ b/src/state/slices/searchSlice.test.tsx
@@ -1,6 +1,11 @@
-import { initialStateFunc, selectDateRangeInLocalTime } from './searchSlice';
+import SearchReducer, {
+  getDefaultMaxShot,
+  initialiseDefaultMaxShots,
+  initialStateFunc,
+  selectDateRangeInLocalTime,
+} from './searchSlice';
 
-describe('Selectors', () => {
+describe('Search slice tests', () => {
   let state: { search: ReturnType<typeof initialStateFunc> };
 
   beforeEach(() => {
@@ -29,5 +34,49 @@ describe('Selectors', () => {
       fromDate: new Date('2025-09-21 11:00:00'),
       toDate: new Date('2025-09-21 12:00:00'),
     });
+  });
+
+  it('initialiseDefaultMaxShots takes max shot config and extracts the default max shot value', () => {
+    expect(state.search.searchParams.maxShots).toBe(50);
+
+    const updatedState = SearchReducer(
+      state.search,
+      initialiseDefaultMaxShots([
+        { value: 100, default: true },
+        { value: 'Unlimited' },
+      ])
+    );
+
+    expect(updatedState.searchParams.maxShots).toBe(100);
+  });
+});
+
+describe('getDefaultMaxShot', () => {
+  it('can get numeric default max shot', () => {
+    expect(
+      getDefaultMaxShot([
+        { value: 100 },
+        { value: 500, default: true },
+        { value: 'Unlimited' },
+      ])
+    ).toBe(500);
+  });
+  it('converts Unlimited max shot to Infinity', () => {
+    expect(
+      getDefaultMaxShot([
+        { value: 100 },
+        { value: 500 },
+        { value: 'Unlimited', default: true },
+      ])
+    ).toBe(Infinity);
+  });
+  it('returns first max shot if no default specified', () => {
+    expect(
+      getDefaultMaxShot([
+        { value: 100 },
+        { value: 500 },
+        { value: 'Unlimited' },
+      ])
+    ).toBe(100);
   });
 });

--- a/src/state/slices/searchSlice.tsx
+++ b/src/state/slices/searchSlice.tsx
@@ -3,11 +3,22 @@ import { createSelector, createSlice } from '@reduxjs/toolkit';
 import { sub } from 'date-fns';
 import { convertApiTimestampToDate, formatDateTimeForApi } from '../../api/api';
 import { SearchParams } from '../../app.types';
-import { MAX_SHOTS_VALUES } from '../../search/components/maxShots.component';
+import { MaxShotType } from '../../settings';
 import { RootState } from '../store';
 import { selectQueryFilters } from './filterSlice';
 import { selectQueryFunctions } from './functionsSlice';
 import { selectPage, selectResultsPerPage, selectSort } from './tableSlice';
+
+export const defaultMaxShots: MaxShotType[] = [
+  { value: 50, default: true },
+  { value: 1000 },
+  { value: 'Unlimited' },
+];
+
+export const getDefaultMaxShot = (maxShots: MaxShotType[]): number => {
+  const maxShot = maxShots.find((x) => x.default)?.value ?? maxShots[0].value;
+  return maxShot === 'Unlimited' ? Infinity : maxShot;
+};
 
 // Define a type for the slice state
 interface SearchState {
@@ -23,7 +34,6 @@ export const initialStateFunc = (): SearchState => {
     hours: 24,
   });
   from.setSeconds(0);
-
   return {
     searchParams: {
       dateRange: {
@@ -31,7 +41,7 @@ export const initialStateFunc = (): SearchState => {
         fromDate: formatDateTimeForApi(from),
       },
       shotnumRange: {},
-      maxShots: MAX_SHOTS_VALUES[0],
+      maxShots: getDefaultMaxShot(defaultMaxShots),
       experimentID: null,
     },
   };
@@ -46,10 +56,17 @@ export const searchSlice = createSlice({
     changeSearchParams: (state, action: PayloadAction<SearchParams>) => {
       state.searchParams = { ...action.payload };
     },
+    initialiseDefaultMaxShots: (
+      state,
+      action: PayloadAction<MaxShotType[]>
+    ) => {
+      state.searchParams.maxShots = getDefaultMaxShot(action.payload);
+    },
   },
 });
 
-export const { changeSearchParams } = searchSlice.actions;
+export const { changeSearchParams, initialiseDefaultMaxShots } =
+  searchSlice.actions;
 
 // Other code such as selectors can use the imported `RootState` type
 export const selectSearchParams = (state: RootState) =>

--- a/src/state/slices/searchSlice.tsx
+++ b/src/state/slices/searchSlice.tsx
@@ -9,7 +9,7 @@ import { selectQueryFilters } from './filterSlice';
 import { selectQueryFunctions } from './functionsSlice';
 import { selectPage, selectResultsPerPage, selectSort } from './tableSlice';
 
-export const defaultMaxShots: MaxShotType[] = [
+export const defaultMaxShotOptions: MaxShotType[] = [
   { value: 50, default: true },
   { value: 1000 },
   { value: 'Unlimited' },
@@ -41,7 +41,7 @@ export const initialStateFunc = (): SearchState => {
         fromDate: formatDateTimeForApi(from),
       },
       shotnumRange: {},
-      maxShots: getDefaultMaxShot(defaultMaxShots),
+      maxShots: getDefaultMaxShot(defaultMaxShotOptions),
       experimentID: null,
     },
   };

--- a/src/views/__snapshots__/viewTabs.component.test.tsx.snap
+++ b/src/views/__snapshots__/viewTabs.component.test.tsx.snap
@@ -622,7 +622,7 @@ exports[`View Tabs > renders correctly 1`] = `
                                   class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-19opgx6-MuiFormControlLabel-root"
                                 >
                                   <span
-                                    aria-label="Select unlimited max shots"
+                                    aria-label="Select Unlimited max shots"
                                     class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-1q72ply-MuiButtonBase-root-MuiSwitchBase-root-MuiRadio-root"
                                   >
                                     <input


### PR DESCRIPTION
## Description
Add a mandatory `maxShots` config option (the previously "default" max shots is now in the example settings) which configures both what the options for max shots should be and which option should be selected by default

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes DSEGOG-529
