### PR TITLE
DSEGOG-484 Add string type

### DIFF
--- a/cypress/e2e/export.cy.ts
+++ b/cypress/e2e/export.cy.ts
@@ -30,8 +30,11 @@ describe('Export', () => {
   it('can select export content', () => {
     cy.findByRole('button', { name: 'Export' }).click();
     cy.findByRole('checkbox', { name: 'Scalars' }).should('be.checked');
+    cy.findByRole('checkbox', { name: 'Strings' }).should('be.checked');
     cy.findByRole('checkbox', { name: 'Images' }).should('not.be.checked');
-    cy.findByRole('checkbox', { name: 'Float Image' }).should('not.be.checked');
+    cy.findByRole('checkbox', { name: 'Float Images' }).should(
+      'not.be.checked'
+    );
     cy.findByRole('checkbox', { name: 'Waveform CSVs' }).should(
       'not.be.checked'
     );
@@ -45,6 +48,7 @@ describe('Export', () => {
     cy.findByRole('checkbox', { name: 'Images' }).click();
     cy.findByRole('checkbox', { name: 'Images' }).should('be.checked');
     cy.findByRole('checkbox', { name: 'Scalars' }).should('be.checked');
+    cy.findByRole('checkbox', { name: 'Strings' }).should('be.checked');
   });
 
   it('should remember options when closed', () => {
@@ -68,7 +72,7 @@ describe('Export', () => {
 
     cy.findByRole('button', { name: 'Export' }).click();
 
-    cy.readFile('./cypress/downloads/scimdownload.csv').should('exist');
+    cy.readFile('./cypress/downloads/scstimdownload.csv').should('exist');
   });
 
   it('should be able to export visible rows', () => {
@@ -76,6 +80,7 @@ describe('Export', () => {
     cy.findByRole('radio', { name: 'Visible Rows' }).click();
 
     cy.findByRole('checkbox', { name: 'Scalars' }).click();
+    cy.findByRole('checkbox', { name: 'Strings' }).click();
     cy.findByRole('checkbox', { name: 'Waveform CSVs' }).click();
     cy.findByRole('checkbox', { name: 'Waveform Images' }).click();
 
@@ -88,13 +93,13 @@ describe('Export', () => {
     cy.findByRole('button', { name: 'Export' }).click();
     cy.findByRole('radio', { name: 'Selected Rows' }).click();
 
-    cy.findByRole('checkbox', { name: 'Float Image' }).click();
+    cy.findByRole('checkbox', { name: 'Float Images' }).click();
     cy.findByRole('checkbox', { name: 'Vector CSVs' }).click();
     cy.findByRole('checkbox', { name: 'Vector Images' }).click();
 
     cy.findByRole('button', { name: 'Export' }).click();
 
-    cy.readFile('./cypress/downloads/scflvcvidownload.csv').should('exist');
+    cy.readFile('./cypress/downloads/scstflvcvidownload.csv').should('exist');
   });
 
   it('should be able to export a image channel', () => {
@@ -116,7 +121,7 @@ describe('Export', () => {
     cy.findByRole('button', { name: 'Export' }).click();
     cy.findByRole('dialog', { name: 'Export Channel' }).should('not.exist');
 
-    cy.readFile('./cypress/downloads/imflwcvcdownload.csv').should('exist');
+    cy.readFile('./cypress/downloads/imdownload.csv').should('exist');
   });
 
   it('should be able to export a float image channel', () => {
@@ -138,7 +143,7 @@ describe('Export', () => {
     cy.findByRole('button', { name: 'Export' }).click();
     cy.findByRole('dialog', { name: 'Export Channel' }).should('not.exist');
 
-    cy.readFile('./cypress/downloads/imflwcvcdownload.csv').should('exist');
+    cy.readFile('./cypress/downloads/fldownload.csv').should('exist');
   });
 
   it('should be able to export a waveform channel', () => {
@@ -159,7 +164,7 @@ describe('Export', () => {
     cy.findByRole('button', { name: 'Export' }).click();
     cy.findByRole('dialog', { name: 'Export Channel' }).should('not.exist');
 
-    cy.readFile('./cypress/downloads/imflwcvcdownload.csv').should('exist');
+    cy.readFile('./cypress/downloads/wcdownload.csv').should('exist');
   });
 
   it('should be able to export a Vector channel', () => {
@@ -180,7 +185,7 @@ describe('Export', () => {
     cy.findByRole('button', { name: 'Export' }).click();
     cy.findByRole('dialog', { name: 'Export Channel' }).should('not.exist');
 
-    cy.readFile('./cypress/downloads/imflwcvcdownload.csv').should('exist');
+    cy.readFile('./cypress/downloads/vcdownload.csv').should('exist');
   });
 
   it('should not be able to export a scalar channel', () => {
@@ -194,6 +199,20 @@ describe('Export', () => {
     cy.findByRole('button', { name: 'Add Channels' }).click();
 
     cy.findByRole('button', { name: 'CHANNEL_ABCDE menu' }).click();
+    cy.findByRole('menuitem', { name: 'Export' }).should('not.exist');
+  });
+
+  it('should not be able to export a string channel', () => {
+    cy.contains('Data Channels').click();
+
+    cy.findByRole('button', { name: 'Channels' }).click();
+    cy.findByRole('button', { name: '1' }).click();
+    cy.findByRole('button', { name: 'Channel_ABCDEX' }).click();
+    cy.findByRole('button', { name: 'Add this channel' }).click();
+
+    cy.findByRole('button', { name: 'Add Channels' }).click();
+
+    cy.findByRole('button', { name: 'CHANNEL_ABCDEX menu' }).click();
     cy.findByRole('menuitem', { name: 'Export' }).should('not.exist');
   });
 });

--- a/cypress/e2e/table.cy.ts
+++ b/cypress/e2e/table.cy.ts
@@ -188,7 +188,9 @@ describe('Table Component', () => {
       `${channelName}{downArrow}{enter}`
     );
 
-    cy.findByRole('checkbox', { name: new RegExp(channelName, 'i') }).check();
+    cy.findByRole('checkbox', {
+      name: new RegExp(`^${channelName}$`, 'i'),
+    }).check();
 
     cy.contains('Add Channels').click();
 

--- a/e2e/real/export.spec.ts
+++ b/e2e/real/export.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-test('should be able to export a CSV of scalar info for all rows', async ({
+test('should be able to export a CSV of scalar and string info for all rows', async ({
   page,
 }) => {
   await page.goto('/');
@@ -148,7 +148,7 @@ test('should be able to export a CSV of float images and vectors for visible row
 
   await page.getByRole('radio', { name: 'Visible Rows' }).check();
 
-  await page.getByRole('checkbox', { name: 'Float Image' }).check();
+  await page.getByRole('checkbox', { name: 'Float Images' }).check();
   await page.getByRole('checkbox', { name: 'Vector CSVs' }).check();
   await page.getByRole('checkbox', { name: 'Vector Images' }).check();
 

--- a/src/api/__snapshots__/records.test.tsx.snap
+++ b/src/api/__snapshots__/records.test.tsx.snap
@@ -4,12 +4,16 @@ exports[`records api functions > useRecordsPaginated > sends request to fetch re
 [
   {
     "CHANNEL_ABCDE": 1,
+    "CHANNEL_ABCDEX": "abcdex",
     "_id": "1",
     "active_area": "ea1",
     "active_experiment": undefined,
     "channelMetadata": {
       "CHANNEL_ABCDE": {
         "channel_dtype": "scalar",
+      },
+      "CHANNEL_ABCDEX": {
+        "channel_dtype": "string",
       },
     },
     "shotnum": 1,

--- a/src/api/channels.tsx
+++ b/src/api/channels.tsx
@@ -12,6 +12,7 @@ import {
   isChannelMetadataFloatImage,
   isChannelMetadataImage,
   isChannelMetadataScalar,
+  isChannelMetadataString,
   isChannelMetadataVector,
   isChannelMetadataWaveform,
   RecordRow,
@@ -42,7 +43,10 @@ interface ChannelsEndpoint {
 }
 
 // This metadata is always present in every record
-export const staticChannels: { [systemName: string]: FullChannelMetadata } = {
+export const staticChannels: Record<
+  typeof timeChannelName | 'shotnum' | 'active_area' | 'active_experiment',
+  FullChannelMetadata
+> = {
   [timeChannelName]: {
     systemName: timeChannelName,
     name: 'Time',
@@ -52,19 +56,19 @@ export const staticChannels: { [systemName: string]: FullChannelMetadata } = {
   shotnum: {
     systemName: 'shotnum',
     name: 'Shot Number',
-    type: 'scalar',
+    type: 'scalar', // can be string for Gemini
     path: '/system',
   },
   active_area: {
     systemName: 'active_area',
     name: 'Active Area',
-    type: 'scalar',
+    type: 'string',
     path: '/system',
   },
   active_experiment: {
     systemName: 'active_experiment',
     name: 'Active Experiment',
-    type: 'scalar',
+    type: 'string',
     path: '/system',
   },
 };
@@ -163,17 +167,22 @@ export const constructColumnDefs = (
       },
       meta: { channelInfo: channel },
       cell: ({ row, getValue }) => {
-        const value = getValue();
         switch (true) {
-          case isChannelMetadataScalar(channel):
-            return typeof value === 'number' &&
-              typeof channel.precision === 'number' ? (
+          case isChannelMetadataScalar(channel): {
+            const value = getValue<number | undefined>();
+            return (
               <React.Fragment>
-                {roundNumber(value, channel.precision, channel.notation)}
+                {value && typeof channel.precision === 'number'
+                  ? roundNumber(value, channel.precision, channel.notation)
+                  : value}
               </React.Fragment>
-            ) : (
-              <React.Fragment>{String(value ?? '')}</React.Fragment>
             );
+          }
+          case isChannelMetadataString(channel): {
+            return (
+              <React.Fragment>{getValue<string | undefined>()}</React.Fragment>
+            );
+          }
           case isChannelMetadataWaveform(channel): {
             const metadata: ChannelMetadata | undefined = (
               row.original as RecordRow
@@ -181,7 +190,7 @@ export const constructColumnDefs = (
 
             return (
               <Base64ImageThumbnail
-                base64Data={value as string}
+                base64Data={getValue<string | undefined>()}
                 alt={`${channel.name ?? channel.systemName} ${channel.type} for timestamp ${row.getValue(timeChannelName)}`}
                 onClick={() => {
                   dispatch(
@@ -213,7 +222,7 @@ export const constructColumnDefs = (
                 : undefined;
             return (
               <Base64ImageThumbnail
-                base64Data={value as string}
+                base64Data={getValue<string | undefined>()}
                 alt={`${channel.name ?? channel.systemName} ${channel.type} for timestamp ${row.getValue(timeChannelName)}`}
                 onClick={() => {
                   dispatch(
@@ -237,7 +246,7 @@ export const constructColumnDefs = (
             const units = isVector ? metadata.units : undefined;
             return (
               <Base64ImageThumbnail
-                base64Data={value as string}
+                base64Data={getValue<string | undefined>()}
                 alt={`${channel.name ?? channel.systemName} ${channel.type} for timestamp ${row.getValue(timeChannelName)}`}
                 onClick={() => {
                   dispatch(

--- a/src/api/export.test.tsx
+++ b/src/api/export.test.tsx
@@ -81,8 +81,9 @@ describe('useExportData', () => {
         exportType: 'Selected Rows',
         dataToExport: {
           Scalars: true,
+          Strings: true,
           Images: false,
-          'Float Image': false,
+          'Float Images': false,
           'Waveform CSVs': true,
           'Waveform Images': false,
           'Vector CSVs': false,
@@ -115,6 +116,7 @@ describe('useExportData', () => {
       })
     );
     params.append('export_scalars', 'true');
+    params.append('export_strings', 'true');
     params.append('export_images', 'false');
     params.append('export_float_images', 'false');
     params.append('export_waveform_csvs', 'true');
@@ -130,7 +132,7 @@ describe('useExportData', () => {
     });
 
     expect(mockLink.href).toContain('blob:');
-    expect(mockLink.download).toEqual('scwcvidownload.csv');
+    expect(mockLink.download).toEqual('scstwcvidownload.csv');
     expect(mockLink.style.display).toEqual('none');
 
     expect(mockLinkClick).toHaveBeenCalled();
@@ -167,8 +169,9 @@ describe('useExportData', () => {
         exportType: 'Selected Rows',
         dataToExport: {
           Scalars: true,
+          Strings: true,
           Images: true,
-          'Float Image': false,
+          'Float Images': false,
           'Waveform CSVs': true,
           'Waveform Images': true,
           'Vector CSVs': true,
@@ -206,6 +209,7 @@ describe('useExportData', () => {
       })
     );
     params.append('export_scalars', 'true');
+    params.append('export_strings', 'true');
     params.append('export_images', 'true');
     params.append('export_float_images', 'false');
     params.append('export_waveform_csvs', 'true');
@@ -221,7 +225,7 @@ describe('useExportData', () => {
     });
 
     expect(mockLink.href).toContain('blob:');
-    expect(mockLink.download).toEqual('scimwcwivcdownload.csv');
+    expect(mockLink.download).toEqual('scstimwcwivcdownload.csv');
     expect(mockLink.style.display).toEqual('none');
 
     expect(mockLinkClick).toHaveBeenCalled();
@@ -241,8 +245,9 @@ describe('useExportData', () => {
         exportType: 'All Rows',
         dataToExport: {
           Scalars: false,
+          Strings: false,
           Images: true,
-          'Float Image': false,
+          'Float Images': false,
           'Waveform CSVs': false,
           'Waveform Images': true,
           'Vector CSVs': false,
@@ -275,6 +280,7 @@ describe('useExportData', () => {
       })
     );
     params.append('export_scalars', 'false');
+    params.append('export_strings', 'false');
     params.append('export_images', 'true');
     params.append('export_float_images', 'false');
     params.append('export_waveform_csvs', 'false');
@@ -310,8 +316,9 @@ describe('useExportData', () => {
         exportType: 'All Rows',
         dataToExport: {
           Scalars: false,
+          Strings: false,
           Images: true,
-          'Float Image': false,
+          'Float Images': false,
           'Waveform CSVs': false,
           'Waveform Images': true,
           'Vector CSVs': true,
@@ -341,6 +348,7 @@ describe('useExportData', () => {
       })
     );
     params.append('export_scalars', 'false');
+    params.append('export_strings', 'false');
     params.append('export_images', 'true');
     params.append('export_float_images', 'false');
     params.append('export_waveform_csvs', 'false');
@@ -376,8 +384,9 @@ describe('useExportData', () => {
         exportType: 'Visible Rows',
         dataToExport: {
           Scalars: true,
+          Strings: true,
           Images: false,
-          'Float Image': false,
+          'Float Images': false,
           'Waveform CSVs': false,
           'Waveform Images': false,
           'Vector CSVs': false,
@@ -411,6 +420,7 @@ describe('useExportData', () => {
       })
     );
     params.append('export_scalars', 'true');
+    params.append('export_strings', 'true');
     params.append('export_images', 'false');
     params.append('export_float_images', 'false');
     params.append('export_waveform_csvs', 'false');
@@ -426,7 +436,7 @@ describe('useExportData', () => {
     });
 
     expect(mockLink.href).toContain('blob:');
-    expect(mockLink.download).toEqual('scdownload.csv');
+    expect(mockLink.download).toEqual('scstdownload.csv');
     expect(mockLink.style.display).toEqual('none');
 
     expect(mockLinkClick).toHaveBeenCalled();
@@ -448,8 +458,9 @@ describe('useExportData', () => {
         exportType: 'All Rows',
         dataToExport: {
           Scalars: true,
+          Strings: false,
           Images: false,
-          'Float Image': false,
+          'Float Images': false,
           'Waveform CSVs': false,
           'Waveform Images': false,
           'Vector CSVs': false,
@@ -483,6 +494,7 @@ describe('useExportData', () => {
       })
     );
     params.append('export_scalars', 'true');
+    params.append('export_strings', 'false');
     params.append('export_images', 'false');
     params.append('export_float_images', 'false');
     params.append('export_waveform_csvs', 'false');

--- a/src/api/export.tsx
+++ b/src/api/export.tsx
@@ -16,8 +16,9 @@ import { staticChannels } from './channels';
 
 export interface DataToExport {
   Scalars: boolean;
+  Strings: boolean;
   Images: boolean;
-  'Float Image': boolean;
+  'Float Images': boolean;
   'Waveform CSVs': boolean;
   'Waveform Images': boolean;
   'Vector CSVs': boolean;
@@ -136,10 +137,14 @@ export const exportData = async (
       'export_scalars',
       JSON.stringify(dataToExport['Scalars'])
     );
+    queryParams.append(
+      'export_strings',
+      JSON.stringify(dataToExport['Strings'])
+    );
     queryParams.append('export_images', JSON.stringify(dataToExport['Images']));
     queryParams.append(
       'export_float_images',
-      JSON.stringify(dataToExport['Float Image'])
+      JSON.stringify(dataToExport['Float Images'])
     );
     queryParams.append(
       'export_waveform_csvs',

--- a/src/api/records.test.tsx
+++ b/src/api/records.test.tsx
@@ -1161,27 +1161,8 @@ describe('records api functions', () => {
       let result = getFormattedAxisData(testRecord, 'shotnum');
       expect(result).toEqual(testRecord.metadata.shotnum);
 
-      testRecord.metadata.shotnum = undefined;
+      testRecord.metadata.shotnum = 'string-shotnum';
       result = getFormattedAxisData(testRecord, 'shotnum');
-      expect(result).toEqual(NaN);
-    });
-
-    it('formats active area correctly', () => {
-      let result = getFormattedAxisData(testRecord, 'active_area');
-      expect(result).toEqual(NaN);
-
-      testRecord.metadata.active_area = '3';
-      result = getFormattedAxisData(testRecord, 'active_area');
-      expect(result).toEqual(parseInt(testRecord.metadata.active_area));
-    });
-
-    it('formats active experiment correctly', () => {
-      testRecord.metadata.active_experiment = '4';
-      let result = getFormattedAxisData(testRecord, 'active_experiment');
-      expect(result).toEqual(parseInt(testRecord.metadata.active_experiment));
-
-      testRecord.metadata.active_experiment = undefined;
-      result = getFormattedAxisData(testRecord, 'active_experiment');
       expect(result).toEqual(NaN);
     });
 
@@ -1191,7 +1172,7 @@ describe('records api functions', () => {
         (testRecord.channels?.['CHANNEL_ABCDE'] as ScalarChannel).data
       );
 
-      (testRecord.channels?.['CHANNEL_ABCDE'] as ScalarChannel).data = '1';
+      (testRecord.channels?.['CHANNEL_ABCDE'] as ScalarChannel).data = 1;
       result = getFormattedAxisData(testRecord, 'CHANNEL_ABCDE');
       expect(result).toEqual(1);
 

--- a/src/api/records.tsx
+++ b/src/api/records.tsx
@@ -10,6 +10,7 @@ import {
   isChannelFloatImage,
   isChannelImage,
   isChannelScalar,
+  isChannelString,
   isChannelVector,
   isChannelWaveform,
   PlotDataset,
@@ -389,7 +390,7 @@ export const useRecordsPaginated = (): UseQueryResult<
           if (channel) {
             let channelData;
 
-            if (isChannelScalar(channel)) {
+            if (isChannelScalar(channel) || isChannelString(channel)) {
               channelData = channel.data;
             } else if (
               isChannelImage(channel) ||
@@ -428,23 +429,10 @@ export const getFormattedAxisData = (
           ? record.metadata.shotnum
           : NaN;
       break;
-    case 'active_area':
-      formattedData = record.metadata.active_area
-        ? parseInt(record.metadata.active_area)
-        : NaN;
-      break;
-    case 'active_experiment':
-      formattedData = record.metadata.active_experiment
-        ? parseInt(record.metadata.active_experiment)
-        : NaN;
-      break;
     default: {
       const channel = record.channels?.[axisName];
       if (isChannelScalar(channel)) {
-        formattedData =
-          typeof channel.data === 'number'
-            ? channel.data
-            : parseFloat(channel.data);
+        formattedData = channel.data;
       }
     }
   }

--- a/src/app.types.tsx
+++ b/src/app.types.tsx
@@ -41,6 +41,11 @@ export interface ScalarMetadata {
   units?: string;
 }
 
+export interface StringMetadata {
+  channel_dtype: 'string';
+  units?: string;
+}
+
 export interface ImageMetadata {
   channel_dtype: 'image';
   x_pixel_size?: number;
@@ -85,7 +90,8 @@ export type DataType =
   | 'image'
   | 'waveform'
   | 'float_image'
-  | 'vector';
+  | 'vector'
+  | 'string';
 
 export interface FullCommonChannelMetadata {
   systemName: string;
@@ -101,6 +107,10 @@ export interface FullScalarChannelMetadata extends FullCommonChannelMetadata {
   precision?: number;
   notation?: 'scientific' | 'normal';
   units?: string;
+}
+
+export interface FullStringChannelMetadata extends FullCommonChannelMetadata {
+  type: 'string';
 }
 
 export interface FullImageChannelMetadata extends FullCommonChannelMetadata {
@@ -128,12 +138,16 @@ export type FullChannelMetadata =
   | FullImageChannelMetadata
   | FullWaveformChannelMetadata
   | FullFloatImageChannelMetadata
-  | FullVectorChannelMetadata;
+  | FullVectorChannelMetadata
+  | FullStringChannelMetadata;
 
 // Type guards because TS can't deal with nested discriminated unions
 export const isChannelMetadataScalar = (
   c: FullChannelMetadata
 ): c is FullScalarChannelMetadata => c.type === 'scalar';
+export const isChannelMetadataString = (
+  c: FullChannelMetadata
+): c is FullStringChannelMetadata => c.type === 'string';
 export const isChannelMetadataImage = (
   c: FullChannelMetadata
 ): c is FullImageChannelMetadata => c.type === 'image';
@@ -152,11 +166,17 @@ export type ChannelMetadata =
   | ImageMetadata
   | WaveformMetadata
   | FloatImageMetadata
-  | VectorMetadata;
+  | VectorMetadata
+  | StringMetadata;
 
 export interface ScalarChannel {
   metadata: ScalarMetadata;
-  data: number | string;
+  data: number;
+}
+
+export interface StringChannel {
+  metadata: StringMetadata;
+  data: string;
 }
 
 export interface ImageChannel {
@@ -188,11 +208,14 @@ export type Channel =
   | ImageChannel
   | WaveformChannel
   | FloatImageChannel
-  | VectorChannel;
+  | VectorChannel
+  | StringChannel;
 
 // Type guards because TS can't deal with nested discriminated unions
 export const isChannelScalar = (c: Channel | undefined): c is ScalarChannel =>
   c?.metadata?.channel_dtype === 'scalar';
+export const isChannelString = (c: Channel | undefined): c is StringChannel =>
+  c?.metadata?.channel_dtype === 'string';
 export const isChannelImage = (c: Channel | undefined): c is ImageChannel =>
   c?.metadata?.channel_dtype === 'image';
 export const isChannelFloatImage = (

--- a/src/channels/__snapshots__/channelMetadataPanel.component.test.tsx.snap
+++ b/src/channels/__snapshots__/channelMetadataPanel.component.test.tsx.snap
@@ -177,6 +177,158 @@ exports[`Channel Metadata Panel > should render correctly for scalar channel wit
 </DocumentFragment>
 `;
 
+exports[`Channel Metadata Panel > should render correctly for string channel 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiStack-root css-3y1137-MuiStack-root"
+  >
+    <h3
+      class="MuiTypography-root MuiTypography-body1 css-lhsbas-MuiTypography-root"
+    >
+      Channel_ABCDEX
+    </h3>
+    <button
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary css-tw6tsg-MuiButtonBase-root-MuiButton-root"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-d8i980-MuiButton-startIcon"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          data-testid="AddIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"
+          />
+        </svg>
+      </span>
+      Add this channel
+    </button>
+  </div>
+  <p
+    class="MuiTypography-root MuiTypography-body2 MuiTypography-gutterBottom css-ytim1c-MuiTypography-root"
+  >
+    System name: CHANNEL_ABCDEX
+  </p>
+  <p
+    class="MuiTypography-root MuiTypography-body2 MuiTypography-gutterBottom css-ytim1c-MuiTypography-root"
+  >
+    Test description
+  </p>
+  <p
+    class="MuiTypography-root MuiTypography-body2 MuiTypography-gutterBottom css-ytim1c-MuiTypography-root"
+  >
+    Channel type: string
+  </p>
+  <hr
+    class="MuiDivider-root MuiDivider-fullWidth css-1jpc804-MuiDivider-root"
+  />
+  <h4
+    class="MuiTypography-root MuiTypography-body2 MuiTypography-gutterBottom css-13wd63j-MuiTypography-root"
+  >
+    Data Summary
+  </h4>
+  <p
+    class="MuiTypography-root MuiTypography-body2 css-7ctihp-MuiTypography-root"
+  >
+    First data date: 2022-01-29 00:00:00
+  </p>
+  <p
+    class="MuiTypography-root MuiTypography-body2 MuiTypography-gutterBottom css-ytim1c-MuiTypography-root"
+  >
+    Most recent data date: 2023-01-31 00:00:00
+  </p>
+  <h5
+    class="MuiTypography-root MuiTypography-body2 MuiTypography-gutterBottom css-13wd63j-MuiTypography-root"
+  >
+    Recent Data
+  </h5>
+  <div
+    class="MuiTableContainer-root css-70zvr5-MuiTableContainer-root"
+  >
+    <table
+      aria-label="recent data"
+      class="MuiTable-root css-1xwxv7r-MuiTable-root"
+    >
+      <thead
+        class="MuiTableHead-root css-1a7iywq-MuiTableHead-root"
+      >
+        <tr
+          class="MuiTableRow-root MuiTableRow-head css-1xtozoh-MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-g6bqb5-MuiTableCell-root"
+            scope="col"
+          >
+            Time
+          </th>
+          <th
+            class="MuiTableCell-root MuiTableCell-head MuiTableCell-sizeSmall css-g6bqb5-MuiTableCell-root"
+            scope="col"
+          >
+            Data
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="MuiTableBody-root css-gmh7jj-MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root css-6phqnb-MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            scope="row"
+          >
+            2022-01-31 00:00:00
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            c
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root css-6phqnb-MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            scope="row"
+          >
+            2022-01-30 00:00:00
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            b
+          </td>
+        </tr>
+        <tr
+          class="MuiTableRow-root css-6phqnb-MuiTableRow-root"
+        >
+          <th
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+            scope="row"
+          >
+            2022-01-29 00:00:00
+          </th>
+          <td
+            class="MuiTableCell-root MuiTableCell-body MuiTableCell-sizeSmall css-jiabcu-MuiTableCell-root"
+          >
+            a
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Channel Metadata Panel > should render correctly for system channel 1`] = `
 <DocumentFragment>
   <div

--- a/src/channels/channelMetadataPanel.component.test.tsx
+++ b/src/channels/channelMetadataPanel.component.test.tsx
@@ -59,6 +59,20 @@ describe('Channel Metadata Panel', () => {
     expect(view.asFragment()).toMatchSnapshot();
   });
 
+  it('should render correctly for string channel', async () => {
+    displayedChannel = {
+      name: 'Channel_ABCDEX',
+      systemName: 'CHANNEL_ABCDEX',
+      type: 'string',
+      path: '/test',
+      description: 'Test description',
+    };
+    const view = createView();
+    await screen.findByText('Data Summary');
+
+    expect(view.asFragment()).toMatchSnapshot();
+  });
+
   it('should render correctly for vector channel with units selected', async () => {
     displayedChannel = {
       name: 'Channel_ABCDE',

--- a/src/channels/channelMetadataPanel.component.tsx
+++ b/src/channels/channelMetadataPanel.component.tsx
@@ -19,6 +19,7 @@ import { useChannelSummary } from '../api/channels';
 import {
   FullChannelMetadata,
   isChannelMetadataScalar,
+  isChannelMetadataString,
   isChannelMetadataVector,
   isChannelMetadataWaveform,
 } from '../app.types';
@@ -223,7 +224,8 @@ const ChannelMetadataPanel = (props: ChannelMetadataPanelProps) => {
                           {formattedTimestamp}
                         </TableCell>
                         <TableCell>
-                          {isChannelMetadataScalar(displayedChannel) ? (
+                          {isChannelMetadataScalar(displayedChannel) ||
+                          isChannelMetadataString(displayedChannel) ? (
                             data
                           ) : (
                             <Base64ImageThumbnail

--- a/src/channels/channelTree.component.test.tsx
+++ b/src/channels/channelTree.component.test.tsx
@@ -16,8 +16,8 @@ describe('Channel Tree', () => {
     systemName: Object.keys(channelsJson.channels)[0],
   } as FullChannelMetadata;
   const channel2 = {
-    ...Object.values(channelsJson.channels)[1],
-    systemName: Object.keys(channelsJson.channels)[1],
+    ...Object.values(channelsJson.channels)[2],
+    systemName: Object.keys(channelsJson.channels)[2],
   } as FullChannelMetadata;
 
   const tree: TreeNode = {

--- a/src/export/exportChannelColumn.component.test.tsx
+++ b/src/export/exportChannelColumn.component.test.tsx
@@ -30,7 +30,7 @@ describe('ExportChannelColumn', () => {
         type: 'image',
       },
     };
-    vi.mocked(useExportData).mockReturnValue({
+    vi.mocked(useExportData, { partial: true }).mockReturnValue({
       mutateAsync: exportData,
     });
 
@@ -51,7 +51,7 @@ describe('ExportChannelColumn', () => {
   });
 
   it('should should pending message', async () => {
-    vi.mocked(useExportData).mockReturnValue({
+    vi.mocked(useExportData, { partial: true }).mockReturnValue({
       mutateAsync: exportData,
       isPending: true,
     });
@@ -63,11 +63,12 @@ describe('ExportChannelColumn', () => {
       exportType: 'All Rows',
       dataToExport: {
         Scalars: false,
+        Strings: false,
         Images: true,
-        'Float Image': true,
-        'Waveform CSVs': true,
+        'Float Images': false,
+        'Waveform CSVs': false,
         'Waveform Images': false,
-        'Vector CSVs': true,
+        'Vector CSVs': false,
         'Vector Images': false,
       },
       selectedColumn: 'TEST-IMAGE',
@@ -76,7 +77,8 @@ describe('ExportChannelColumn', () => {
     expect(screen.getByText('Generating export data...')).toBeVisible();
   });
 
-  it('handles export click', async () => {
+  it('handles export click for float image type', async () => {
+    props.channelInfo.type = 'float_image';
     createView();
 
     const exportButton = screen.getByText('Export');
@@ -85,9 +87,58 @@ describe('ExportChannelColumn', () => {
       exportType: 'All Rows',
       dataToExport: {
         Scalars: false,
-        Images: true,
-        'Float Image': true,
+        Strings: false,
+        Images: false,
+        'Float Images': true,
+        'Waveform CSVs': false,
+        'Waveform Images': false,
+        'Vector CSVs': false,
+        'Vector Images': false,
+      },
+      selectedColumn: 'TEST-IMAGE',
+    });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('handles export click for waveform type', async () => {
+    props.channelInfo.type = 'waveform';
+    createView();
+
+    const exportButton = screen.getByText('Export');
+    await user.click(exportButton);
+    expect(exportData).toHaveBeenCalledWith({
+      exportType: 'All Rows',
+      dataToExport: {
+        Scalars: false,
+        Strings: false,
+        Images: false,
+        'Float Images': false,
         'Waveform CSVs': true,
+        'Waveform Images': false,
+        'Vector CSVs': false,
+        'Vector Images': false,
+      },
+      selectedColumn: 'TEST-IMAGE',
+    });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('handles export click for vector type', async () => {
+    props.channelInfo.type = 'vector';
+    createView();
+
+    const exportButton = screen.getByText('Export');
+    await user.click(exportButton);
+    expect(exportData).toHaveBeenCalledWith({
+      exportType: 'All Rows',
+      dataToExport: {
+        Scalars: false,
+        Strings: false,
+        Images: false,
+        'Float Images': false,
+        'Waveform CSVs': false,
         'Waveform Images': false,
         'Vector CSVs': true,
         'Vector Images': false,

--- a/src/export/exportChannelColumn.component.tsx
+++ b/src/export/exportChannelColumn.component.tsx
@@ -28,11 +28,12 @@ const ExportChannelColumn = (props: ExportChannelColumnProps) => {
       exportType: 'All Rows',
       dataToExport: {
         Scalars: false,
-        Images: true,
-        'Float Image': true,
-        'Waveform CSVs': true,
+        Strings: false,
+        Images: channelInfo.type === 'image',
+        'Float Images': channelInfo.type === 'float_image',
+        'Waveform CSVs': channelInfo.type === 'waveform',
         'Waveform Images': false,
-        'Vector CSVs': true,
+        'Vector CSVs': channelInfo.type === 'vector',
         'Vector Images': false,
       },
       selectedColumn: channelInfo.systemName,
@@ -43,7 +44,7 @@ const ExportChannelColumn = (props: ExportChannelColumnProps) => {
       .catch((error: AxiosError) => {
         handleOG_APIError(error);
       });
-  }, [channelInfo.systemName, exportChannels, onClose]);
+  }, [channelInfo.systemName, channelInfo.type, exportChannels, onClose]);
 
   return (
     <>

--- a/src/export/exportDialogue.component.test.tsx
+++ b/src/export/exportDialogue.component.test.tsx
@@ -12,7 +12,7 @@ describe('ExportDialogue', () => {
   let user: ReturnType<typeof userEvent.setup>;
 
   beforeEach(() => {
-    vi.mocked(useExportData).mockReturnValue({
+    vi.mocked(useExportData, { partial: true }).mockReturnValue({
       mutateAsync: vi.fn(),
     });
 
@@ -67,7 +67,7 @@ describe('ExportDialogue', () => {
   it('handles export click', async () => {
     const onCloseMock = vi.fn();
     const exportData = vi.fn().mockResolvedValue({});
-    vi.mocked(useExportData).mockReturnValue({
+    vi.mocked(useExportData, { partial: true }).mockReturnValue({
       mutateAsync: exportData,
       isPending: true,
     });
@@ -81,8 +81,9 @@ describe('ExportDialogue', () => {
       exportType: 'All Rows',
       dataToExport: {
         Scalars: true,
+        Strings: true,
         Images: false,
-        'Float Image': false,
+        'Float Images': false,
         'Waveform CSVs': false,
         'Waveform Images': false,
         'Vector CSVs': false,

--- a/src/export/exportDialogue.component.tsx
+++ b/src/export/exportDialogue.component.tsx
@@ -33,8 +33,9 @@ const ExportDialogue = (props: ExportDialogueProps) => {
   const [selectedExportContent, setSelectedExportContent] =
     React.useState<DataToExport>({
       Scalars: true,
+      Strings: true,
       Images: false,
-      'Float Image': false,
+      'Float Images': false,
       'Waveform CSVs': false,
       'Waveform Images': false,
       'Vector CSVs': false,

--- a/src/filtering/filterDialogue.component.test.tsx
+++ b/src/filtering/filterDialogue.component.test.tsx
@@ -279,7 +279,7 @@ describe('Filter dialogue component', () => {
     expect(filters).toHaveLength(2);
 
     const [filter1, filter2] = filters;
-    await user.type(filter1, 'Act{enter}is{enter}');
+    await user.type(filter1, 'ch{enter}is{enter}');
     await user.type(filter2, 'sh{enter}={enter}1{enter}');
     await user.tab();
 
@@ -290,8 +290,8 @@ describe('Filter dialogue component', () => {
       [
         {
           type: 'channel',
-          value: 'active_area',
-          label: 'Active Area',
+          value: 'CHANNEL_ABCDE',
+          label: 'Channel_ABCDE',
         },
         operators.find((t) => t.value === 'is not null')!,
       ],
@@ -409,7 +409,7 @@ describe('Filter dialogue component', () => {
     expect(screen.getAllByRole('combobox', { name: 'Filter' })).toHaveLength(2);
 
     const filter1 = screen.getAllByRole('combobox', { name: 'Filter' })[0];
-    await user.type(filter1, 'Act{enter}is{enter}');
+    await user.type(filter1, 'sh{enter}is{enter}');
     await user.tab();
 
     expect(screen.getByText('Apply')).not.toBeDisabled();
@@ -435,8 +435,8 @@ describe('Filter dialogue component', () => {
       [
         {
           type: 'channel',
-          value: 'active_area',
-          label: 'Active Area',
+          value: 'shotnum',
+          label: 'Shot Number',
         },
         operators.find((t) => t.value === 'is not null')!,
       ],
@@ -458,7 +458,7 @@ describe('Filter dialogue component', () => {
     expect(screen.getAllByRole('combobox', { name: 'Filter' })).toHaveLength(2);
 
     const filter1 = screen.getAllByRole('combobox', { name: 'Filter' })[0];
-    await user.type(filter1, 'Act{enter}is{enter}');
+    await user.type(filter1, 'sh{enter}is{enter}');
     await user.tab();
 
     expect(screen.getByText('Apply')).not.toBeDisabled();
@@ -553,7 +553,7 @@ describe('Filter dialogue component', () => {
             shotnumRange: {},
             experimentID: null,
           },
-          filters: ['{"metadata.active_area":{"$ne":null}}'],
+          filters: ['{"metadata.shotnum":{"$ne":null}}'],
         },
       ],
       () => {
@@ -578,7 +578,7 @@ describe('Filter dialogue component', () => {
     const { store } = createView(state, testQueryClient);
 
     const filter = screen.getByRole('combobox', { name: 'Filter' });
-    await user.type(filter, 'Act{enter}is{enter}');
+    await user.type(filter, 'sh{enter}is{enter}');
     await user.tab();
 
     expect(screen.getByText('Apply')).not.toBeDisabled();
@@ -593,8 +593,8 @@ describe('Filter dialogue component', () => {
       [
         {
           type: 'channel',
-          value: 'active_area',
-          label: 'Active Area',
+          value: 'shotnum',
+          label: 'Shot Number',
         },
         operators.find((t) => t.value === 'is not null')!,
       ],

--- a/src/mocks/channels.json
+++ b/src/mocks/channels.json
@@ -6,6 +6,11 @@
       "path": "/Channels/1",
       "type": "scalar"
     },
+    "CHANNEL_ABCDEX": {
+      "name": "Channel_ABCDEX",
+      "path": "/Channels/1",
+      "type": "string"
+    },
     "CHANNEL_BCDEF": {
       "name": "Channel_BCDEF",
       "path": "/Channels/1",

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -420,7 +420,7 @@ export const handlers = [
     );
     const arrBuffer = uintarr.buffer;
 
-    const testString = `${url.searchParams.get('export_scalars') === 'true' ? 'sc' : ''}${url.searchParams.get('export_images') === 'true' ? 'im' : ''}${url.searchParams.get('export_float_images') === 'true' ? 'fl' : ''}${url.searchParams.get('export_waveform_csvs') === 'true' ? 'wc' : ''}${url.searchParams.get('export_waveform_images') === 'true' ? 'wi' : ''}${url.searchParams.get('export_vector_csvs') === 'true' ? 'vc' : ''}${url.searchParams.get('export_vector_images') === 'true' ? 'vi' : ''}`;
+    const testString = `${url.searchParams.get('export_scalars') === 'true' ? 'sc' : ''}${url.searchParams.get('export_strings') === 'true' ? 'st' : ''}${url.searchParams.get('export_images') === 'true' ? 'im' : ''}${url.searchParams.get('export_float_images') === 'true' ? 'fl' : ''}${url.searchParams.get('export_waveform_csvs') === 'true' ? 'wc' : ''}${url.searchParams.get('export_waveform_images') === 'true' ? 'wi' : ''}${url.searchParams.get('export_vector_csvs') === 'true' ? 'vc' : ''}${url.searchParams.get('export_vector_images') === 'true' ? 'vi' : ''}`;
     return new HttpResponse(arrBuffer, {
       headers: {
         'Content-Type': 'text/plain',

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -4,6 +4,7 @@ import {
   APIErrorResponse,
   Channel,
   isChannelScalar,
+  isChannelString,
   PREFERRED_COLOUR_MAP_PREFERENCE_NAME,
   PREFERRED_NULLABLE_COLOUR_MAP_PREFERENCE_NAME,
   Record,
@@ -277,11 +278,17 @@ export const handlers = [
                 { '2022-01-30T00:00:00': 5 },
                 { '2022-01-29T00:00:00': 4 },
               ]
-            : [
-                { '2022-01-31T00:00:00': channel?.thumbnail },
-                { '2022-01-30T00:00:00': channel?.thumbnail },
-                { '2022-01-29T00:00:00': channel?.thumbnail },
-              ],
+            : isChannelString(channel)
+              ? [
+                  { '2022-01-31T00:00:00': 'c' },
+                  { '2022-01-30T00:00:00': 'b' },
+                  { '2022-01-29T00:00:00': 'a' },
+                ]
+              : [
+                  { '2022-01-31T00:00:00': channel?.thumbnail },
+                  { '2022-01-30T00:00:00': channel?.thumbnail },
+                  { '2022-01-29T00:00:00': channel?.thumbnail },
+                ],
         },
         { status: 200 }
       );

--- a/src/mocks/records.json
+++ b/src/mocks/records.json
@@ -13,6 +13,12 @@
           "channel_dtype": "scalar"
         },
         "data": 1
+      },
+      "CHANNEL_ABCDEX": {
+        "metadata": {
+          "channel_dtype": "string"
+        },
+        "data": "abcdex"
       }
     }
   },

--- a/src/plotting/plotSettings/__snapshots__/plotSettingsController.component.test.tsx.snap
+++ b/src/plotting/plotSettings/__snapshots__/plotSettingsController.component.test.tsx.snap
@@ -89,18 +89,6 @@ changeXAxis=undefined
     "path": "/system"
   },
   {
-    "systemName": "active_area",
-    "name": "Active Area",
-    "type": "scalar",
-    "path": "/system"
-  },
-  {
-    "systemName": "active_experiment",
-    "name": "Active Experiment",
-    "type": "scalar",
-    "path": "/system"
-  },
-  {
     "systemName": "CHANNEL_ABCDE",
     "name": "Channel_ABCDE",
     "path": "/Channels/1",
@@ -170,18 +158,6 @@ allChannels=[
   {
     "systemName": "shotnum",
     "name": "Shot Number",
-    "type": "scalar",
-    "path": "/system"
-  },
-  {
-    "systemName": "active_area",
-    "name": "Active Area",
-    "type": "scalar",
-    "path": "/system"
-  },
-  {
-    "systemName": "active_experiment",
-    "name": "Active Experiment",
     "type": "scalar",
     "path": "/system"
   },
@@ -335,18 +311,6 @@ changeXAxis=undefined
   {
     "systemName": "shotnum",
     "name": "Shot Number",
-    "type": "scalar",
-    "path": "/system"
-  },
-  {
-    "systemName": "active_area",
-    "name": "Active Area",
-    "type": "scalar",
-    "path": "/system"
-  },
-  {
-    "systemName": "active_experiment",
-    "name": "Active Experiment",
     "type": "scalar",
     "path": "/system"
   },
@@ -528,18 +492,6 @@ allChannels=[
   {
     "systemName": "shotnum",
     "name": "Shot Number",
-    "type": "scalar",
-    "path": "/system"
-  },
-  {
-    "systemName": "active_area",
-    "name": "Active Area",
-    "type": "scalar",
-    "path": "/system"
-  },
-  {
-    "systemName": "active_experiment",
-    "name": "Active Experiment",
     "type": "scalar",
     "path": "/system"
   },

--- a/src/plotting/plotSettings/moreOptions/__snapshots__/moreOptionsBox.component.test.tsx.snap
+++ b/src/plotting/plotSettings/moreOptions/__snapshots__/moreOptionsBox.component.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`MoreOptionsBox > renders correctly 1`] = `
           class="MuiSwitch-root MuiSwitch-sizeSmall css-r1g42g-MuiSwitch-root"
         >
           <span
-            aria-label="toggle active_area visibility off"
+            aria-label="toggle CHANNEL_ABCDE visibility off"
             class="MuiButtonBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary Mui-checked PrivateSwitchBase-root MuiSwitch-switchBase MuiSwitch-colorPrimary Mui-checked Mui-checked css-aqlqb4-MuiButtonBase-root-MuiSwitchBase-root-MuiSwitch-switchBase"
           >
             <input
@@ -53,7 +53,7 @@ exports[`MoreOptionsBox > renders correctly 1`] = `
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiNativeSelect-root css-xpsklr-MuiInputBase-root-MuiInput-root"
         >
           <select
-            aria-label="change active_area line style"
+            aria-label="change CHANNEL_ABCDE line style"
             class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input css-1xaqj7c-MuiNativeSelect-root-MuiNativeSelect-select-MuiInputBase-input-MuiInput-input"
           >
             <option
@@ -105,7 +105,7 @@ exports[`MoreOptionsBox > renders correctly 1`] = `
           >
             <input
               aria-invalid="false"
-              aria-label="change active_area line width"
+              aria-label="change CHANNEL_ABCDE line width"
               class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1pzfmz2-MuiInputBase-input-MuiOutlinedInput-input"
               id=":r0:"
               max="10"
@@ -148,7 +148,7 @@ exports[`MoreOptionsBox > renders correctly 1`] = `
           class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiNativeSelect-root css-xpsklr-MuiInputBase-root-MuiInput-root"
         >
           <select
-            aria-label="change active_area marker style"
+            aria-label="change CHANNEL_ABCDE marker style"
             class="MuiNativeSelect-select MuiNativeSelect-standard MuiInputBase-input MuiInput-input css-1xaqj7c-MuiNativeSelect-root-MuiNativeSelect-select-MuiInputBase-input-MuiInput-input"
           >
             <option
@@ -235,7 +235,7 @@ exports[`MoreOptionsBox > renders correctly 1`] = `
           >
             <input
               aria-invalid="false"
-              aria-label="change active_area marker size"
+              aria-label="change CHANNEL_ABCDE marker size"
               class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1pzfmz2-MuiInputBase-input-MuiOutlinedInput-input"
               id=":r1:"
               max="15"
@@ -279,7 +279,7 @@ exports[`MoreOptionsBox > renders correctly 1`] = `
         >
           <button
             aria-haspopup="dialog"
-            aria-label="Pick active_area colour"
+            aria-label="Pick CHANNEL_ABCDE colour"
             class="MuiBox-root css-129yjn7"
           />
         </div>

--- a/src/plotting/plotSettings/moreOptions/__snapshots__/moreOptionsToggle.component.test.tsx.snap
+++ b/src/plotting/plotSettings/moreOptions/__snapshots__/moreOptionsToggle.component.test.tsx.snap
@@ -91,7 +91,7 @@ selectedPlotChannels=[
     }
   },
   {
-    "name": "active_area",
+    "name": "CHANNEL_ABCDE",
     "units": "mm",
     "options": {
       "visible": true,
@@ -101,7 +101,7 @@ selectedPlotChannels=[
     }
   },
   {
-    "name": "active_experiment",
+    "name": "CHANNEL_DEFGH",
     "units": "mm",
     "options": {
       "visible": true,

--- a/src/state/slices/configSlice.test.tsx
+++ b/src/state/slices/configSlice.test.tsx
@@ -23,11 +23,13 @@ vi.mock('loglevel');
 
 describe('configSlice', () => {
   const originalActiveArea = staticChannels['active_area'];
+  const originalShotNum = staticChannels['shotnum'];
 
   beforeEach(() => {
     staticChannels['active_area'] = JSON.parse(
       JSON.stringify(originalActiveArea)
     );
+    staticChannels['shotnum'] = JSON.parse(JSON.stringify(originalShotNum));
   });
 
   // normally can test reducers in components, but since configSlice is high level
@@ -198,6 +200,7 @@ describe('configSlice', () => {
       expect(actions).toContainEqual(loadDataTypesSetting(['GS', 'GD']));
       expect(actions).toContainEqual(initialiseDataTypes(['GS', 'GD']));
       expect(staticChannels['active_area'].name).toBe('Data Type');
+      expect(staticChannels['shotnum'].type).toBe('string');
 
       expect(actions).toContainEqual(settingsLoaded());
     });

--- a/src/state/slices/configSlice.tsx
+++ b/src/state/slices/configSlice.tsx
@@ -135,6 +135,8 @@ export const configureApp = () => async (dispatch: AppDispatch) => {
       // change active_area to read as data type
       staticChannels['active_area'].name = 'Data Type';
       columnIconMappings.set('active_area', <Category />);
+      // set type of shot number channel to string
+      staticChannels['shotnum'].type = 'string';
     }
 
     dispatch(settingsLoaded());

--- a/src/views/recordTable.component.test.tsx
+++ b/src/views/recordTable.component.test.tsx
@@ -25,7 +25,7 @@ describe('Record Table', () => {
 
   let uuidCount = 0;
 
-  const createView = (initialState = state) => {
+  const createView = (initialState: Partial<RootState> = state) => {
     return renderComponentWithProviders(
       <RecordTable openFilters={openFilters} tableHeight="100px" />,
       {
@@ -272,7 +272,22 @@ describe('Record Table', () => {
       timeout: 5000,
     });
 
-    expect(screen.getByText('3.3e+2')).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: '3.3e+2' })).toBeInTheDocument();
+  });
+
+  it('renders string channels correctly', async () => {
+    createView({
+      table: {
+        ...state.table,
+        selectedColumnIds: ['timestamp', 'CHANNEL_ABCDEX'],
+      },
+    });
+
+    await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'), {
+      timeout: 5000,
+    });
+
+    expect(screen.getByRole('cell', { name: 'abcdex' })).toBeInTheDocument();
   });
 
   it("updates columns when a column's word wrap is toggled", async () => {


### PR DESCRIPTION
## Description
Adds the `string` channel type. Note that `scalar` was previously allowed to be either a number or a string - this was erroneous as `scalar` was always intended to be just numbers so it is now just `number`. This has some knock on effects to `active_area` and `active_experiment`, which are now `string` type, and expands the `dataTypes` configuration to also change the channel type of `shotnum` from `number` to `string` as well. This affects things such as not being able to plot these channels anymore, etc.

Also fixed `Float Image` -> `Float Images` in the export dialogue to match the phrasing of the other options.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [x] Test against gemini API with a channel like `GEM_SHOT_TYPE_STRING` which is a `string` channel

## Agile board tracking
Part of DSEGOG-484
