### PR TITLE
DSEGOG-552 user office login

### DIFF
--- a/cypress/e2e/users.cy.ts
+++ b/cypress/e2e/users.cy.ts
@@ -1,8 +1,9 @@
 describe('Users', () => {
-  it('should users table correctly', () => {
+  it('should show users table correctly', () => {
     cy.visit('/admin/users');
     cy.findByText('user1').should('exist');
     cy.findAllByText('FedID').should('have.length', 5);
+    cy.findAllByText('user12@example.com').should('exist');
     cy.findAllByText('/users POST').should('have.length', 3);
   });
 
@@ -32,21 +33,9 @@ describe('Users', () => {
       cy.findByText('Username is required.').should('exist');
     });
 
-    it('displays password field only when auth_type is "local"', () => {
-      cy.findByLabelText('Username *').type('new_user');
-      cy.findByLabelText('Password *').should('exist');
-    });
-
-    it('dose not displays password field only when auth_type is "FedID"', () => {
-      cy.findAllByRole('combobox').first().click();
-      cy.findByRole('option', { name: 'FedID' }).click();
-
-      cy.findByLabelText('Username *').type('new_user');
-      cy.findByLabelText('Password *').should('not.exist');
-    });
-
     it('adds user successfully (local)', () => {
       cy.findByLabelText('Username *').type('new_user');
+      cy.findByLabelText('Password *').should('exist');
       cy.findByLabelText('Password *').type('secure_password');
 
       cy.findAllByRole('combobox').last().click();
@@ -80,6 +69,8 @@ describe('Users', () => {
       cy.findAllByRole('combobox').first().click();
       cy.findByRole('option', { name: 'FedID' }).click();
 
+      cy.findByLabelText('Password *').should('not.exist');
+
       cy.startSnoopingBrowserMockedRequest();
 
       cy.findByRole('button', { name: 'Submit' }).click();
@@ -90,6 +81,28 @@ describe('Users', () => {
           const request = postRequests[0];
           expect(JSON.stringify(await request.json())).equal(
             JSON.stringify({ _id: 'new_user', auth_type: 'FedID' })
+          );
+        }
+      );
+    });
+
+    it('adds user successfully (user_office)', () => {
+      cy.findAllByRole('combobox').first().click();
+      cy.findByRole('option', { name: 'user_office' }).click();
+
+      cy.findByLabelText('Email *').type('new_user');
+      cy.findByLabelText('Password *').should('not.exist');
+
+      cy.startSnoopingBrowserMockedRequest();
+
+      cy.findByRole('button', { name: 'Submit' }).click();
+
+      cy.findBrowserMockedRequests({ method: 'POST', url: '/users' }).should(
+        async (postRequests) => {
+          expect(postRequests.length).equal(1);
+          const request = postRequests[0];
+          expect(JSON.stringify(await request.json())).equal(
+            JSON.stringify({ _id: 'new_user', auth_type: 'user_office' })
           );
         }
       );

--- a/public/operationsgateway-settings.example.json
+++ b/public/operationsgateway-settings.example.json
@@ -7,6 +7,7 @@
     { "value": "Unlimited" }
   ],
   "workingHours": { "start": 9, "end": 18 },
+  "authTypes": ["local", "FedID"],
   "dataTypes": [],
   "plotAxisSigFigs": ".3~s",
   "routes": [

--- a/server/e2e-settings-mocked.json
+++ b/server/e2e-settings-mocked.json
@@ -7,6 +7,7 @@
     { "value": "Unlimited" }
   ],
   "workingHours": { "start": 9, "end": 18 },
+  "authTypes": ["local", "FedID", "user_office"],
   "plotAxisSigFigs": ".3~s",
   "routes": [
     {

--- a/src/admin/users/deleteUserDialogue.component.test.tsx
+++ b/src/admin/users/deleteUserDialogue.component.test.tsx
@@ -45,7 +45,7 @@ describe('delete user dialogue', () => {
   it('displays warning message when user data does not exist in database', async () => {
     props = {
       ...props,
-      selectedUser: { ...UsersJson[0], username: 'test' },
+      selectedUser: { ...UsersJson[0], _id: 'test' },
     };
     createView();
 

--- a/src/admin/users/deleteUserDialogue.component.tsx
+++ b/src/admin/users/deleteUserDialogue.component.tsx
@@ -32,7 +32,7 @@ const DeleteUserDialogue = (props: DeleteUserDialogueProps) => {
   }, [onClose]);
 
   const handleDeleteUser = React.useCallback(() => {
-    deleteUser(selectedUser.username)
+    deleteUser(selectedUser._id)
       .then(() => {
         handleClose();
       })
@@ -49,8 +49,7 @@ const DeleteUserDialogue = (props: DeleteUserDialogueProps) => {
       <DialogTitle>Delete User</DialogTitle>
       <DialogContent>
         Are you sure you want to delete{' '}
-        <strong data-testid="delete-user-name">{selectedUser?.username}</strong>
-        ?
+        <strong data-testid="delete-user-name">{selectedUser.username}</strong>?
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Close</Button>

--- a/src/admin/users/userDialogue.component.test.tsx
+++ b/src/admin/users/userDialogue.component.test.tsx
@@ -16,7 +16,12 @@ describe('userDialogue', () => {
   };
 
   beforeEach(() => {
-    props = { onClose: onClose, open: true, requestType: 'post' };
+    props = {
+      onClose: onClose,
+      open: true,
+      requestType: 'post',
+      authTypes: ['local', 'FedID', 'user_office'],
+    };
     user = userEvent.setup();
   });
 
@@ -55,7 +60,7 @@ describe('userDialogue', () => {
       expect(screen.getByLabelText('Password *')).toBeInTheDocument();
     });
 
-    it('does not display password field only when auth_type is "FedID"', async () => {
+    it('does not display password field when auth_type is not "local"', async () => {
       createView();
       await user.type(screen.getByLabelText('Username *'), 'new_user');
       const [authType, _routes] = screen.getAllByRole('combobox');
@@ -105,8 +110,8 @@ describe('userDialogue', () => {
       });
     });
 
-    it('adds user successfully (fedId) switch from local to fedId', async () => {
-      // This tests that the password is removed if you switch from local to fedId
+    it('adds user successfully (user_office) after switching from local to user_office', async () => {
+      // This tests that the password is removed if you switch from local to non-local
       createView();
 
       await user.type(screen.getByLabelText('Username *'), 'new_user');
@@ -115,13 +120,17 @@ describe('userDialogue', () => {
       const [authType, _routes] = screen.getAllByRole('combobox');
 
       await user.click(authType);
-      await user.click(await screen.findByText('FedID'));
+      await user.click(await screen.findByText('user_office'));
+
+      // check it switches the field name to email
+      expect(screen.getByLabelText('Email *')).toHaveValue('new_user');
+      expect(screen.queryByLabelText('Password *')).not.toBeInTheDocument();
 
       await user.click(screen.getByText('Submit'));
 
       expect(axiosPostSpy).toHaveBeenCalledWith('/users', {
         _id: 'new_user',
-        auth_type: 'FedID',
+        auth_type: 'user_office',
       });
     });
 

--- a/src/admin/users/userDialogue.component.tsx
+++ b/src/admin/users/userDialogue.component.tsx
@@ -18,7 +18,8 @@ import { Controller, useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { useAddUser, useEditUser } from '../../api/user';
 import { APIError, UserPatch, UserPost, type User } from '../../app.types';
-import { AUTH_TYPE_LIST, AUTHORISED_ROUTE_LIST } from './usersTable.component';
+import { AuthTypesType } from '../../settings';
+import { AUTHORISED_ROUTE_LIST } from './usersTable.component';
 
 export interface UserDialogueProps {
   onClose: () => void;
@@ -27,6 +28,7 @@ export interface UserDialogueProps {
   selectedUser?: User;
   passwordOnly?: boolean;
   authorisedRoutesOnly?: boolean;
+  authTypes: AuthTypesType;
 }
 
 interface BaseZodSchemaProps {
@@ -65,6 +67,7 @@ const UserDialogue = (props: UserDialogueProps) => {
     selectedUser,
     passwordOnly,
     authorisedRoutesOnly,
+    authTypes,
   } = props;
 
   const isNotAdding = requestType !== 'post' && selectedUser;
@@ -99,7 +102,7 @@ const UserDialogue = (props: UserDialogueProps) => {
   });
   const userFormData = watch();
   React.useEffect(() => {
-    if (userFormData.auth_type === 'FedID') {
+    if (userFormData.auth_type !== 'local') {
       setValue('sha256_password', undefined);
     }
   }, [setValue, userFormData.auth_type]);
@@ -140,7 +143,7 @@ const UserDialogue = (props: UserDialogueProps) => {
     (user: UserPost) => {
       if (!selectedUser) return;
 
-      const patchUsers: UserPatch = { _id: selectedUser.username };
+      const patchUsers: UserPatch = { _id: selectedUser._id };
 
       if (passwordOnly && !user.sha256_password) {
         setError('sha256_password', {
@@ -234,7 +237,7 @@ const UserDialogue = (props: UserDialogueProps) => {
             render={({ field }) => (
               <Autocomplete
                 {...field}
-                options={AUTH_TYPE_LIST}
+                options={authTypes}
                 disableClearable
                 getOptionLabel={(option) => option}
                 onChange={(_, value) => field.onChange(value)}
@@ -255,12 +258,14 @@ const UserDialogue = (props: UserDialogueProps) => {
         {(passwordOnly || requestType === 'post') && (
           <TextField
             {...register('_id')}
-            label={'Username'}
+            label={
+              userFormData.auth_type === 'user_office' ? 'Email' : 'Username'
+            }
             id="user-id"
             fullWidth
             required
             disabled={requestType === 'patch'}
-            autoComplete="new-password"
+            autoComplete="new-username"
             margin="dense"
             error={!!errors._id}
             helperText={errors._id?.message}

--- a/src/admin/users/usersTable.component.tsx
+++ b/src/admin/users/usersTable.component.tsx
@@ -21,6 +21,8 @@ import { MRT_Localization_EN } from 'material-react-table/locales/en';
 import React from 'react';
 import { useUsers } from '../../api/user';
 import { User } from '../../app.types';
+import { useAppSelector } from '../../state/hooks';
+import { selectAuthTypes } from '../../state/slices/configSlice';
 import DeleteUserDialogue from './deleteUserDialogue.component';
 import UserDialogue from './userDialogue.component';
 
@@ -37,7 +39,6 @@ export const AUTHORISED_ROUTE_LIST = [
   '/scheduled_maintenance PUT',
 ];
 
-export const AUTH_TYPE_LIST = ['local', 'FedID'];
 function UsersTable() {
   const { data: userData, isLoading: userDataLoading } = useUsers();
 
@@ -48,6 +49,7 @@ function UsersTable() {
   const [selectedUser, setSelectedUser] = React.useState<User | undefined>(
     undefined
   );
+  const authTypes = useAppSelector(selectAuthTypes);
 
   // Define the columns for the table
   const columns: MRT_ColumnDef<User>[] = [
@@ -57,7 +59,7 @@ function UsersTable() {
       accessorKey: 'auth_type',
       header: 'Auth Type',
       filterVariant: 'autocomplete',
-      filterSelectOptions: AUTH_TYPE_LIST,
+      filterSelectOptions: authTypes,
     },
     {
       accessorKey: 'authorised_routes',
@@ -130,6 +132,7 @@ function UsersTable() {
           onClose={() => {
             table.setCreatingRow(null);
           }}
+          authTypes={authTypes}
         />
       );
     },

--- a/src/app.types.tsx
+++ b/src/app.types.tsx
@@ -415,7 +415,7 @@ export interface APIError {
 type AuthorisedRoutes = string[] | null;
 
 export interface UserPost {
-  _id: string; // Maps the `username` field in Python, which has an alias "_id"
+  _id: string;
   auth_type: string;
   sha256_password?: string;
   authorised_routes?: AuthorisedRoutes;
@@ -426,8 +426,8 @@ export interface UserPatch extends Pick<UserPost, '_id'> {
   add_authorised_routes?: AuthorisedRoutes;
   remove_authorised_routes?: AuthorisedRoutes;
 }
-export interface User extends Omit<UserPost, '_id' | 'sha256_password'> {
-  username: string;
+export interface User extends Omit<UserPost, 'sha256_password'> {
+  username: string; // username is the display name - _id is the what the backend needs for any user operations
 }
 
 export interface UsersDict {

--- a/src/mocks/users.json
+++ b/src/mocks/users.json
@@ -1,43 +1,52 @@
 [
   {
+    "_id": "user1",
     "username": "user1",
     "auth_type": "local",
     "authorised_routes": ["/submit/hdf POST", "/submit/manifest POST"]
   },
   {
+    "_id": "user2",
     "username": "user2",
     "auth_type": "FedID",
     "authorised_routes": ["/records/{id_} DELETE", "/experiments POST"]
   },
   {
+    "_id": "user3",
     "username": "user3",
     "auth_type": "local",
     "authorised_routes": ["/users POST", "/users PATCH"]
   },
   {
+    "_id": "user4",
     "username": "user4",
     "auth_type": "FedID",
     "authorised_routes": ["/users/{id_} DELETE"]
   },
   {
+    "_id": "user5",
     "username": "user5",
     "auth_type": "local",
     "authorised_routes": null
   },
   {
+    "_id": "user6",
     "username": "user6",
     "auth_type": "FedID",
     "authorised_routes": null
   },
   {
+    "_id": "user7",
     "username": "user7",
     "auth_type": "local"
   },
   {
+    "_id": "user8",
     "username": "user8",
     "auth_type": "FedID"
   },
   {
+    "_id": "user9",
     "username": "user9",
     "auth_type": "local",
     "authorised_routes": [
@@ -51,13 +60,20 @@
     ]
   },
   {
+    "_id": "user10",
     "username": "user10",
     "auth_type": "FedID",
     "authorised_routes": []
   },
   {
+    "_id": "user11",
     "username": "user11",
     "auth_type": "local",
     "authorised_routes": ["/users POST", "/users PATCH"]
+  },
+  {
+    "_id": "user12",
+    "username": "user12@example.com",
+    "auth_type": "user_office"
   }
 ]

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -258,6 +258,32 @@ describe('fetchSettings', () => {
     );
   });
 
+  it('logs an error if one of the authTypes is an invalid type in the settings', async () => {
+    server.use(
+      http.get('/operationsgateway-settings.json', () =>
+        HttpResponse.json(
+          {
+            apiUrl: 'api',
+            recordLimitWarning: -1,
+            maxShots: defaultMaxShotOptions,
+            authTypes: ['error'],
+          },
+          { status: 200 }
+        )
+      )
+    );
+
+    const settings = await fetchSettings();
+
+    expect(settings).toBeUndefined();
+    expect(log.error).toHaveBeenCalled();
+
+    const mockLog = vi.mocked(log.error).mock;
+    expect(mockLog.calls[0][0]).toEqual(
+      'Error loading /operationsgateway-settings.json: Unrecognised auth type defined in the settings'
+    );
+  });
+
   it('logs an error if settings.json is an invalid JSON object', async () => {
     server.use(
       http.get('/operationsgateway-settings.json', () =>

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,6 +15,8 @@ export interface MaxShotType {
   default?: boolean;
 }
 
+export type AuthTypesType = ('local' | 'FedID' | 'user_office')[];
+
 export interface OperationsGatewaySettings {
   apiUrl: string;
   recordLimitWarning: number;
@@ -25,6 +27,7 @@ export interface OperationsGatewaySettings {
   workingHours?: WorkingHours;
   plotAxisSigFigs?: string;
   dataTypes?: string[];
+  authTypes?: AuthTypesType;
 }
 
 export let settings: Promise<OperationsGatewaySettings | void>;
@@ -76,6 +79,15 @@ export const fetchSettings = (): Promise<OperationsGatewaySettings | void> => {
         throw new Error(
           'Some max shots have a non-number, non-"Unlimited" value in the settings'
         );
+      }
+
+      if (
+        settings.authTypes?.some(
+          (auth) =>
+            auth !== 'local' && auth !== 'FedID' && auth !== 'user_office'
+        )
+      ) {
+        throw new Error('Unrecognised auth type defined in the settings');
       }
 
       if (Array.isArray(settings['routes']) && settings['routes'].length) {

--- a/src/state/slices/configSlice.test.tsx
+++ b/src/state/slices/configSlice.test.tsx
@@ -4,6 +4,7 @@ import { actions, dispatch, resetActions } from '../../testUtils';
 import ConfigReducer, {
   configureApp,
   initialState,
+  loadAuthTypesSetting,
   loadDataTypesSetting,
   loadMaxShotsSetting,
   loadPlotAxisSigFigsSetting,
@@ -141,6 +142,17 @@ describe('configSlice', () => {
 
       expect(updatedState.dataTypes).toEqual(['GS', 'GD']);
     });
+
+    it('should set authTypes property when loadAuthTypesSetting action is sent', () => {
+      expect(state.authTypes).toEqual(['local', 'FedID']);
+
+      const updatedState = ConfigReducer(
+        state,
+        loadAuthTypesSetting(['user_office'])
+      );
+
+      expect(updatedState.authTypes).toEqual(['user_office']);
+    });
   });
 
   describe('Actions', () => {
@@ -166,12 +178,13 @@ describe('configSlice', () => {
           workingHours: { start: 10, end: 17 },
           plotAxisSigFigs: '.2~s',
           dataTypes: ['GS', 'GD'],
+          authTypes: ['FedID'],
         })
       );
       const asyncAction = configureApp();
       await asyncAction(dispatch);
 
-      expect(actions.length).toEqual(10);
+      expect(actions.length).toEqual(11);
       expect(actions).toContainEqual(
         loadUrls({
           apiUrl: 'api',
@@ -201,11 +214,12 @@ describe('configSlice', () => {
       expect(actions).toContainEqual(initialiseDataTypes(['GS', 'GD']));
       expect(staticChannels['active_area'].name).toBe('Data Type');
       expect(staticChannels['shotnum'].type).toBe('string');
+      expect(actions).toContainEqual(loadAuthTypesSetting(['FedID']));
 
       expect(actions).toContainEqual(settingsLoaded());
     });
 
-    it("doesn't send loadPluginHostSetting, loadPlotAxisSigFigsSetting and loadWorkingHoursSetting actions or configure data types when they're not defined", async () => {
+    it("doesn't send loadPluginHostSetting, loadPlotAxisSigFigsSetting, loadAuthTypesSetting and loadWorkingHoursSetting actions or configure data types when they're not defined", async () => {
       setSettings(
         Promise.resolve({
           apiUrl: 'api',
@@ -242,6 +256,9 @@ describe('configSlice', () => {
         actions.every(({ type }) => type !== initialiseDataTypes.type)
       ).toBe(true);
       expect(staticChannels['active_area'].name).toBe('Active Area');
+      expect(
+        actions.every(({ type }) => type !== loadAuthTypesSetting.type)
+      ).toBe(true);
 
       expect(actions).toContainEqual(settingsLoaded());
     });

--- a/src/state/slices/configSlice.tsx
+++ b/src/state/slices/configSlice.tsx
@@ -3,7 +3,12 @@ import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import { staticChannels } from '../../api/channels';
 import { columnIconMappings } from '../../app.types';
-import { MaxShotType, settings, type WorkingHours } from '../../settings';
+import {
+  AuthTypesType,
+  MaxShotType,
+  settings,
+  type WorkingHours,
+} from '../../settings';
 import { AppDispatch, RootState } from '../store';
 import {
   defaultMaxShotOptions,
@@ -25,6 +30,7 @@ interface ConfigState {
   workingHours: WorkingHours;
   plotAxisSigFigs?: string;
   dataTypes?: string[];
+  authTypes: AuthTypesType;
 }
 
 // Define the initial state using that type
@@ -38,6 +44,7 @@ export const initialState: ConfigState = {
   settingsLoaded: false,
   workingHours: { start: 9, end: 18 },
   dataTypes: undefined,
+  authTypes: ['local', 'FedID'],
 };
 
 export const configSlice = createSlice({
@@ -73,6 +80,9 @@ export const configSlice = createSlice({
     loadDataTypesSetting: (state, action: PayloadAction<string[]>) => {
       state.dataTypes = action.payload;
     },
+    loadAuthTypesSetting: (state, action: PayloadAction<AuthTypesType>) => {
+      state.authTypes = action.payload;
+    },
   },
 });
 
@@ -85,6 +95,7 @@ export const {
   loadWorkingHoursSetting,
   loadPlotAxisSigFigsSetting,
   loadDataTypesSetting,
+  loadAuthTypesSetting,
 } = configSlice.actions;
 
 export const selectUrls = (state: RootState) => state.config.urls;
@@ -96,6 +107,7 @@ export const selectWorkingHours = (state: RootState) =>
 export const selectPlotAxisSigFigs = (state: RootState) =>
   state.config.plotAxisSigFigs;
 export const selectDataTypes = (state: RootState) => state.config.dataTypes;
+export const selectAuthTypes = (state: RootState) => state.config.authTypes;
 
 // Defining a thunk
 export const configureApp = () => async (dispatch: AppDispatch) => {
@@ -137,6 +149,11 @@ export const configureApp = () => async (dispatch: AppDispatch) => {
       columnIconMappings.set('active_area', <Category />);
       // set type of shot number channel to string
       staticChannels['shotnum'].type = 'string';
+    }
+
+    const authTypes = settingsResult.authTypes;
+    if (typeof authTypes !== 'undefined') {
+      dispatch(loadAuthTypesSetting(authTypes));
     }
 
     dispatch(settingsLoaded());


### PR DESCRIPTION
## Description
Add ability to add user office users - to do this the backend now returns the `_id` of a user in the `GET /users` endpoint as for a user office user their `_id` and `username` will differ.

Added an `auth_types` config option to control which auth types to allow to be added.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Test against OG gemini

## Agile board tracking
connect to DSEGOG-{issue number}
